### PR TITLE
Issue 10 port number isnt correctly retrieved from the bookmarks.toml

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@
 
 Released on FIXME:
 
+- Bugfix:
+  - [Issue 10](https://github.com/veeso/termscp/issues/10): Fixed port not being loaded from bookmarks into gui
+
 ## 0.4.0
 
 Released on 27/03/2021

--- a/src/ui/activities/auth_activity/bookmarks.rs
+++ b/src/ui/activities/auth_activity/bookmarks.rs
@@ -251,7 +251,7 @@ impl AuthActivity {
             self.view.update(super::COMPONENT_INPUT_ADDR, props);
         }
         if let Some(mut props) = self.view.get_props(super::COMPONENT_INPUT_PORT) {
-            let props = props.with_value(PropValue::Unsigned(port as usize)).build();
+            let props = props.with_value(PropValue::Str(port.to_string())).build();
             self.view.update(super::COMPONENT_INPUT_PORT, props);
         }
         if let Some(mut props) = self.view.get_props(super::COMPONENT_RADIO_PROTOCOL) {


### PR DESCRIPTION
# Port number isnt correctly retrieved from the bookmarks.toml

Fixes #10 

## Description

Fixed wrong set_value for the text component while loading port.. Was using Unsigned instead of String.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
