### PR TITLE
[BUG] Issue 9 some problems with symlinks hash and backslash characters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ Released on FIXME:
 
 - Bugfix:
   - [Issue 10](https://github.com/veeso/termscp/issues/10): Fixed port not being loaded from bookmarks into gui
+  - [Issue 9](https://github.com/veeso/termscp/issues/9): Fixed issues related to paths on remote when using Windows
+- Dependencies:
+  - Added `path-slash 0.1.4` (Windows only)
 
 ## 0.4.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -931,6 +931,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "path-slash"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3cacbb3c4ff353b534a67fb8d7524d00229da4cb1dc8c79f4db96e375ab5b619"
+
+[[package]]
 name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1397,6 +1403,7 @@ dependencies = [
  "keyring",
  "lazy_static",
  "magic-crypt",
+ "path-slash",
  "rand 0.8.2",
  "regex",
  "rpassword",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,17 @@ ureq = { version = "2.0.2", features = ["json"] }
 whoami = "1.1.0"
 wildmatch = "1.0.13"
 
+# POSIX dependencies
 [target.'cfg(any(target_os = "unix", target_os = "macos", target_os = "linux"))'.dependencies]
 users = "0.11.0"
 
+# Windows + MacOS
 [target.'cfg(any(target_os = "windows", target_os = "macos"))'.dependencies]
 keyring = "0.10.1"
+
+# Windows dependencies
+[target.'cfg(target_os = "windows")'.dependencies]
+path-slash = "0.1.4"
 
 # Features
 [features]


### PR DESCRIPTION
# Windows issues related to backslash when on Linux remote (SCP/FTP)

Fixes #9 

## Description

To solve the issue, a module which converts paths from Windows to POSIX is necessary. This won't introduce any issue with windows because:

- Windows SCP server always support SFTP (and atm scp doesn't support windows at all)
- On FTP this doersn't introduce any issue

Changes:

- Added `path_slash` to dependencies
- Added `resolve` method to FTP/SCP file transfers to replace backslashes with slashes

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
