### PR TITLE
[BUG] every ftp transfer is made in ascii mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 Released on FIXME:
 
 - Bugfix:
+  - [Issue 18](https://github.com/veeso/termscp/issues/18): Set file transfer type to `Binary` for FTP
   - [Issue 10](https://github.com/veeso/termscp/issues/10): Fixed port not being loaded from bookmarks into gui
   - [Issue 9](https://github.com/veeso/termscp/issues/9): Fixed issues related to paths on remote when using Windows
 - Dependencies:

--- a/src/filetransfer/ftp_transfer.rs
+++ b/src/filetransfer/ftp_transfer.rs
@@ -329,7 +329,7 @@ impl FileTransfer for FtpFileTransfer {
             Err(err) => {
                 return Err(FileTransferError::new_ex(
                     FileTransferErrorType::ConnectionError,
-                    format!("{}", err),
+                    err.to_string(),
                 ))
             }
         };
@@ -344,7 +344,7 @@ impl FileTransfer for FtpFileTransfer {
                 Err(err) => {
                     return Err(FileTransferError::new_ex(
                         FileTransferErrorType::SslError,
-                        format!("{}", err),
+                        err.to_string(),
                     ))
                 }
             };
@@ -353,7 +353,7 @@ impl FileTransfer for FtpFileTransfer {
                 Err(err) => {
                     return Err(FileTransferError::new_ex(
                         FileTransferErrorType::SslError,
-                        format!("{}", err),
+                        err.to_string(),
                     ))
                 }
             };
@@ -396,7 +396,7 @@ impl FileTransfer for FtpFileTransfer {
                 Ok(_) => Ok(()),
                 Err(err) => Err(FileTransferError::new_ex(
                     FileTransferErrorType::ConnectionError,
-                    format!("{}", err),
+                    err.to_string(),
                 )),
             },
             None => Err(FileTransferError::new(
@@ -422,7 +422,7 @@ impl FileTransfer for FtpFileTransfer {
                 Ok(path) => Ok(PathBuf::from(path.as_str())),
                 Err(err) => Err(FileTransferError::new_ex(
                     FileTransferErrorType::ConnectionError,
-                    format!("{}", err),
+                    err.to_string(),
                 )),
             },
             None => Err(FileTransferError::new(
@@ -442,7 +442,7 @@ impl FileTransfer for FtpFileTransfer {
                 Ok(_) => Ok(dir),
                 Err(err) => Err(FileTransferError::new_ex(
                     FileTransferErrorType::ConnectionError,
-                    format!("{}", err),
+                    err.to_string(),
                 )),
             },
             None => Err(FileTransferError::new(
@@ -482,7 +482,7 @@ impl FileTransfer for FtpFileTransfer {
                 }
                 Err(err) => Err(FileTransferError::new_ex(
                     FileTransferErrorType::DirStatFailed,
-                    format!("{}", err),
+                    err.to_string(),
                 )),
             },
             None => Err(FileTransferError::new(
@@ -501,7 +501,7 @@ impl FileTransfer for FtpFileTransfer {
                 Ok(_) => Ok(()),
                 Err(err) => Err(FileTransferError::new_ex(
                     FileTransferErrorType::FileCreateDenied,
-                    format!("{}", err),
+                    err.to_string(),
                 )),
             },
             None => Err(FileTransferError::new(
@@ -527,7 +527,7 @@ impl FileTransfer for FtpFileTransfer {
                     Ok(_) => Ok(()),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::PexError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -540,7 +540,7 @@ impl FileTransfer for FtpFileTransfer {
                             if let Err(err) = self.remove(&file) {
                                 return Err(FileTransferError::new_ex(
                                     FileTransferErrorType::PexError,
-                                    format!("{}", err),
+                                    err.to_string(),
                                 ));
                             }
                         }
@@ -549,13 +549,13 @@ impl FileTransfer for FtpFileTransfer {
                             Ok(_) => Ok(()),
                             Err(err) => Err(FileTransferError::new_ex(
                                 FileTransferErrorType::PexError,
-                                format!("{}", err),
+                                err.to_string(),
                             )),
                         }
                     }
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::DirStatFailed,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -588,7 +588,7 @@ impl FileTransfer for FtpFileTransfer {
                     Ok(_) => Ok(()),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::FileCreateDenied,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -638,7 +638,7 @@ impl FileTransfer for FtpFileTransfer {
                 Ok(writer) => Ok(Box::new(writer)), // NOTE: don't use BufWriter here, since already returned by the library
                 Err(err) => Err(FileTransferError::new_ex(
                     FileTransferErrorType::FileCreateDenied,
-                    format!("{}", err),
+                    err.to_string(),
                 )),
             },
             None => Err(FileTransferError::new(
@@ -657,7 +657,7 @@ impl FileTransfer for FtpFileTransfer {
                 Ok(reader) => Ok(Box::new(reader)), // NOTE: don't use BufReader here, since already returned by the library
                 Err(err) => Err(FileTransferError::new_ex(
                     FileTransferErrorType::NoSuchFileOrDirectory,
-                    format!("{}", err),
+                    err.to_string(),
                 )),
             },
             None => Err(FileTransferError::new(
@@ -679,7 +679,7 @@ impl FileTransfer for FtpFileTransfer {
                 Ok(_) => Ok(()),
                 Err(err) => Err(FileTransferError::new_ex(
                     FileTransferErrorType::ProtocolError,
-                    format!("{}", err),
+                    err.to_string(),
                 )),
             },
             None => Err(FileTransferError::new(
@@ -701,7 +701,7 @@ impl FileTransfer for FtpFileTransfer {
                 Ok(_) => Ok(()),
                 Err(err) => Err(FileTransferError::new_ex(
                     FileTransferErrorType::ProtocolError,
-                    format!("{}", err),
+                    err.to_string(),
                 )),
             },
             None => Err(FileTransferError::new(

--- a/src/filetransfer/ftp_transfer.rs
+++ b/src/filetransfer/ftp_transfer.rs
@@ -38,7 +38,7 @@ use crate::utils::parser::{parse_datetime, parse_lstime};
 
 // Includes
 use ftp4::native_tls::TlsConnector;
-use ftp4::FtpStream;
+use ftp4::{types::FileType, FtpStream};
 use regex::Regex;
 use std::path::{Path, PathBuf};
 use std::time::SystemTime;
@@ -370,7 +370,14 @@ impl FileTransfer for FtpFileTransfer {
         if let Err(err) = stream.login(username.as_str(), password.as_str()) {
             return Err(FileTransferError::new_ex(
                 FileTransferErrorType::AuthenticationFailed,
-                format!("{}", err),
+                err.to_string(),
+            ));
+        }
+        // Initialize file type
+        if let Err(err) = stream.transfer_type(FileType::Binary) {
+            return Err(FileTransferError::new_ex(
+                FileTransferErrorType::ProtocolError,
+                err.to_string(),
             ));
         }
         // Set stream

--- a/src/filetransfer/scp_transfer.rs
+++ b/src/filetransfer/scp_transfer.rs
@@ -315,7 +315,7 @@ impl FileTransfer for ScpFileTransfer {
                 Err(err) => {
                     return Err(FileTransferError::new_ex(
                         FileTransferErrorType::BadAddress,
-                        format!("{}", err),
+                        err.to_string(),
                     ))
                 }
             };
@@ -346,7 +346,7 @@ impl FileTransfer for ScpFileTransfer {
             Err(err) => {
                 return Err(FileTransferError::new_ex(
                     FileTransferErrorType::ConnectionError,
-                    format!("{}", err),
+                    err.to_string(),
                 ))
             }
         };
@@ -356,7 +356,7 @@ impl FileTransfer for ScpFileTransfer {
         if let Err(err) = session.handshake() {
             return Err(FileTransferError::new_ex(
                 FileTransferErrorType::ConnectionError,
-                format!("{}", err),
+                err.to_string(),
             ));
         }
         let username: String = match username {
@@ -378,7 +378,7 @@ impl FileTransfer for ScpFileTransfer {
                 ) {
                     return Err(FileTransferError::new_ex(
                         FileTransferErrorType::AuthenticationFailed,
-                        format!("{}", err),
+                        err.to_string(),
                     ));
                 }
             }
@@ -390,7 +390,7 @@ impl FileTransfer for ScpFileTransfer {
                 ) {
                     return Err(FileTransferError::new_ex(
                         FileTransferErrorType::AuthenticationFailed,
-                        format!("{}", err),
+                        err.to_string(),
                     ));
                 }
             }
@@ -422,7 +422,7 @@ impl FileTransfer for ScpFileTransfer {
                     }
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ConnectionError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -492,7 +492,7 @@ impl FileTransfer for ScpFileTransfer {
                     }
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ProtocolError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -534,7 +534,7 @@ impl FileTransfer for ScpFileTransfer {
                     }
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ProtocolError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -573,7 +573,7 @@ impl FileTransfer for ScpFileTransfer {
                     }
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ProtocolError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -610,7 +610,7 @@ impl FileTransfer for ScpFileTransfer {
                     }
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ProtocolError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -647,7 +647,7 @@ impl FileTransfer for ScpFileTransfer {
                     }
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ProtocolError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -689,7 +689,7 @@ impl FileTransfer for ScpFileTransfer {
                     }
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ProtocolError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -744,7 +744,7 @@ impl FileTransfer for ScpFileTransfer {
                     }
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ProtocolError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -765,7 +765,7 @@ impl FileTransfer for ScpFileTransfer {
                     Ok(output) => Ok(output),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ProtocolError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -824,7 +824,7 @@ impl FileTransfer for ScpFileTransfer {
                     Ok(channel) => Ok(Box::new(BufWriter::with_capacity(65536, channel))),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ProtocolError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -847,7 +847,7 @@ impl FileTransfer for ScpFileTransfer {
                     Ok(reader) => Ok(Box::new(BufReader::with_capacity(65536, reader.0))),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ProtocolError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }

--- a/src/filetransfer/sftp_transfer.rs
+++ b/src/filetransfer/sftp_transfer.rs
@@ -76,12 +76,12 @@ impl SftpFileTransfer {
                         Ok(_) => Ok(p),
                         Err(err) => Err(FileTransferError::new_ex(
                             FileTransferErrorType::NoSuchFileOrDirectory,
-                            format!("{}", err),
+                            err.to_string(),
                         )),
                     },
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::NoSuchFileOrDirectory,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -90,7 +90,7 @@ impl SftpFileTransfer {
                     Ok(_) => Ok(p),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::NoSuchFileOrDirectory,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 },
                 Err(_) => Err(FileTransferError::new(
@@ -260,7 +260,7 @@ impl FileTransfer for SftpFileTransfer {
                 Err(err) => {
                     return Err(FileTransferError::new_ex(
                         FileTransferErrorType::BadAddress,
-                        format!("{}", err),
+                        err.to_string(),
                     ))
                 }
             };
@@ -291,7 +291,7 @@ impl FileTransfer for SftpFileTransfer {
             Err(err) => {
                 return Err(FileTransferError::new_ex(
                     FileTransferErrorType::ConnectionError,
-                    format!("{}", err),
+                    err.to_string(),
                 ))
             }
         };
@@ -301,7 +301,7 @@ impl FileTransfer for SftpFileTransfer {
         if let Err(err) = session.handshake() {
             return Err(FileTransferError::new_ex(
                 FileTransferErrorType::ConnectionError,
-                format!("{}", err),
+                err.to_string(),
             ));
         }
         let username: String = match username {
@@ -323,7 +323,7 @@ impl FileTransfer for SftpFileTransfer {
                 ) {
                     return Err(FileTransferError::new_ex(
                         FileTransferErrorType::AuthenticationFailed,
-                        format!("{}", err),
+                        err.to_string(),
                     ));
                 }
             }
@@ -335,7 +335,7 @@ impl FileTransfer for SftpFileTransfer {
                 ) {
                     return Err(FileTransferError::new_ex(
                         FileTransferErrorType::AuthenticationFailed,
-                        format!("{}", err),
+                        err.to_string(),
                     ));
                 }
             }
@@ -348,7 +348,7 @@ impl FileTransfer for SftpFileTransfer {
             Err(err) => {
                 return Err(FileTransferError::new_ex(
                     FileTransferErrorType::ProtocolError,
-                    format!("{}", err),
+                    err.to_string(),
                 ))
             }
         };
@@ -358,7 +358,7 @@ impl FileTransfer for SftpFileTransfer {
             Err(err) => {
                 return Err(FileTransferError::new_ex(
                     FileTransferErrorType::ProtocolError,
-                    format!("{}", err),
+                    err.to_string(),
                 ))
             }
         };
@@ -386,7 +386,7 @@ impl FileTransfer for SftpFileTransfer {
                     }
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::ConnectionError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -459,7 +459,7 @@ impl FileTransfer for SftpFileTransfer {
                 match sftp.readdir(dir.as_path()) {
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::DirStatFailed,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                     Ok(files) => {
                         // Allocate vector
@@ -490,7 +490,7 @@ impl FileTransfer for SftpFileTransfer {
                     Ok(_) => Ok(()),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::FileCreateDenied,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -517,7 +517,7 @@ impl FileTransfer for SftpFileTransfer {
                     Ok(_) => Ok(()),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::PexError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -538,7 +538,7 @@ impl FileTransfer for SftpFileTransfer {
                     Ok(_) => Ok(()),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::PexError,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -562,7 +562,7 @@ impl FileTransfer for SftpFileTransfer {
                     Ok(_) => Ok(()),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::FileCreateDenied,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -585,7 +585,7 @@ impl FileTransfer for SftpFileTransfer {
                     Ok(metadata) => Ok(self.make_fsentry(dir.as_path(), &metadata)),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::NoSuchFileOrDirectory,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -604,7 +604,7 @@ impl FileTransfer for SftpFileTransfer {
                 Ok(output) => Ok(output),
                 Err(err) => Err(FileTransferError::new_ex(
                     FileTransferErrorType::ProtocolError,
-                    format!("{}", err),
+                    err.to_string(),
                 )),
             },
             false => Err(FileTransferError::new(
@@ -643,7 +643,7 @@ impl FileTransfer for SftpFileTransfer {
                     Ok(file) => Ok(Box::new(BufWriter::with_capacity(65536, file))),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::FileCreateDenied,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }
@@ -669,7 +669,7 @@ impl FileTransfer for SftpFileTransfer {
                     Ok(file) => Ok(Box::new(BufReader::with_capacity(65536, file))),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::NoSuchFileOrDirectory,
-                        format!("{}", err),
+                        err.to_string(),
                     )),
                 }
             }


### PR DESCRIPTION
# Every ftp transfer is made in ascii mode

Fixes #18 

## Description

Currently the FTP file transfer, file are transferred using ASCII mode. This method corrupts binary files (and also text files tbh). The method should be changed to Binary.

List here your changes

- On connect method, the ftp client sets transfer type to `Binary`
- Error messages are now stringified using `to_string()`

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] Any dependent changes have been merged and published in downstream modules
