### PR TITLE
[BUG] Problems with symlinks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,12 @@
 
 Released on FIXME:
 
+- Enhancements:
+  - SCP file transfer:
+    - Added possibility to stat directories.
 - Bugfix:
+  - [Issue 17](https://github.com/veeso/termscp/issues/17)
+    - SCP: fixed symlink not properly detected
   - [Issue 10](https://github.com/veeso/termscp/issues/10): Fixed port not being loaded from bookmarks into gui
   - [Issue 9](https://github.com/veeso/termscp/issues/9): Fixed issues related to paths on remote when using Windows
 - Dependencies:
@@ -37,6 +42,8 @@ Released on FIXME:
 ## 0.4.0
 
 Released on 27/03/2021
+
+> The UI refactoring update
 
 - **New explorer features**:
   - **Execute** a command pressing `X`. This feature is supported on both local and remote hosts (only SFTP/SCP protocols support this feature).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Released on FIXME:
   - [Issue 18](https://github.com/veeso/termscp/issues/18): Set file transfer type to `Binary` for FTP
   - [Issue 17](https://github.com/veeso/termscp/issues/17)
     - SCP: fixed symlink not properly detected
+    - FTP: added symlink support for Linux targets
   - [Issue 10](https://github.com/veeso/termscp/issues/10): Fixed port not being loaded from bookmarks into gui
   - [Issue 9](https://github.com/veeso/termscp/issues/9): Fixed issues related to paths on remote when using Windows
 - Dependencies:


### PR DESCRIPTION
# Problems with symlinks

Fixes #17 

## Description

FTP file transfer:

- I still can't enter inside symlinks but it works with the Goto command
- I can now browse and enter inside the directories 

SFTP (Windows 10?):

- I can't enter inside symlinks at all and they are now considered like files
so the Goto command doesn't work
- I can enter the symlinks using the Goto command without your solution)

Changes performed:

- Fixed symlinks in SCP

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] Any dependent changes have been merged and published in downstream modules
