### PR TITLE
One-liner for installing with Homebrew 😅

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,8 +154,7 @@ You can install TermSCP on MacOS using [brew](https://brew.sh/)
 From your terminal run
 
 ```sh
-brew tap veeso/termscp
-brew install termscp
+brew install veeso/termscp/termscp
 ```
 
 ---


### PR DESCRIPTION
Hi! Thank you so much for `termscp`.

Just one nit: the two commands used in the README to install termscp using Homebrew can be folded into one command.

This:

```sh
brew install veeso/termscp/termscp
```

is equivalent to the two commands

```sh
brew tap veeso/termscp
brew install termscp
```

Thanks!