### PR TITLE
Work on multiple files in explorers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,8 +25,14 @@ Released on FIXME: ??
   - Added the possibility to enabled the synchronized brower navigation
     - when you enter a directory, the same directory will be entered on the other tab
     - Enable sync browser with `<Y>`
+    - Read more on manual: [Synchronized browsing](docs/man.md#Synchronized-browsing-)
 - **Remote and Local hosts file formatter**:
   - Added the possibility to set different formatters for local and remote hosts
+- **Work on multiple files**:
+  - Added the possibility to work on **multiple files simultaneously**
+  - Select a file with `<M>`, the file when selected will have a `*` prepended to its name
+  - Select all files in the current directory with `<CTRL+A>`
+  - Read more on manual: [Work on multiple files](docs/man.md#Work-on-multiple-files-)
 - Enhancements
   - Added a status bar in the file explorer showing whether the sync browser is enabled and which file sorting mode is selected
   - Removed the goold old figlet title

--- a/README.md
+++ b/README.md
@@ -184,8 +184,6 @@ The developer documentation can be found on Rust Docs at <https://docs.rs/termsc
 
 - **Themes provider 🎨**: I'm still thinking about how I will implement this, but basically the idea is to have a configuration file where it will be possible
     to define the color schema for the entire application. I haven't planned this release yet
-- **Synchronized browsing of local and remote directories ⌚**: See [Issue 8](https://github.com/veeso/termscp/issues/8)
-- **Group file select 🤩**: Possibility to select a group of files in explorers to operate on
 
 No other new feature is planned at the moment. I actually think that termscp is getting mature and now I should focus upcoming updates more on bug fixing and code/performance improvements than on new features.
 Anyway there are some ideas which I'd like to implement. If you want to start working on them, feel free to open a PR:

--- a/docs/man.md
+++ b/docs/man.md
@@ -4,7 +4,10 @@
   - [Usage ❓](#usage-)
     - [Address argument 🌎](#address-argument-)
       - [How Password can be provided 🔐](#how-password-can-be-provided-)
-  - [Keybindings ⌨](#keybindings-)
+  - [File explorer 📂](#file-explorer-)
+    - [Keybindings ⌨](#keybindings-)
+    - [Work on multiple files 🥷](#work-on-multiple-files-)
+    - [Synchronized browsing ⏲️](#synchronized-browsing-️)
   - [Bookmarks ⭐](#bookmarks-)
     - [Are my passwords Safe 😈](#are-my-passwords-safe-)
   - [Configuration ⚙️](#configuration-️)
@@ -76,7 +79,18 @@ Password can be basically provided through 3 ways when address argument is provi
 
 ---
 
-## Keybindings ⌨
+## File explorer 📂
+
+When we refer to file explorers in termscp, we refer to the panels you can see after establishing a connection with the remote.
+These panels are basically 3 (yes, three actually):
+
+- Local explorer panel: it is displayed on the left of your screen and shows the current directory entries for localhost
+- Remote explorer panel: it is displayed on the right of your screen and shows the current directory entries for the remote host.
+- Find results panel: depending on where you're searching for files (local/remote) it will replace the local or the explorer panel. This panel shows the entries matching the search query you performed.
+
+In order to change panel you need to type `<LEFT>` to move the remote explorer panel and `<RIGHT>` to move back to the local explorer panel. Whenever you are in the find results panel, you need to press `<ESC>` to exit panel and go back to the previous panel.
+
+### Keybindings ⌨
 
 | Key           | Command                                               | Reminder    |
 |---------------|-------------------------------------------------------|-------------|
@@ -100,7 +114,8 @@ Password can be basically provided through 3 ways when address argument is provi
 | `<G>`         | Go to supplied path                                   | Go to       |
 | `<H>`         | Show help                                             | Help        |
 | `<I>`         | Show info about selected file or directory            | Info        |
-| `<L>`         | Reload current directory's content                    | List        |
+| `<L>`         | Reload current directory's content / Clear selection  | List        |
+| `<M>`         | Select a file                                         | Mark         |
 | `<N>`         | Create new file with provided name                    | New         |
 | `<O>`         | Edit file; see [Text editor](#text-editor-)           | Open        |
 | `<Q>`         | Quit termscp                                          | Quit        |
@@ -110,7 +125,27 @@ Password can be basically provided through 3 ways when address argument is provi
 | `<X>`         | Execute a command                                     | eXecute     |
 | `<Y>`         | Toggle synchronized browsing                          | sYnc        |
 | `<DEL>`       | Delete file                                           |             |
+| `<CTRL+A>`    | Select all files                                      |             |
 | `<CTRL+C>`    | Abort file transfer process                           |             |
+
+### Work on multiple files 🥷
+
+You can opt to work on multiple files, selecting them pressing `<M>`, in order to select the current file, or pressing `<CTRL+A>`, which will select all the files in the working directory.
+Once a file is marked for selection, it will be displayed with a `*` on the left.
+When working on selection, only selected file will be processed for actions, while the current highlighted item will be ignored.
+It is possible to work on multiple files also when in the find result panel.
+All the actions are available when working with multiple files, but be aware that some actions work in a slightly different way. Let's dive in:
+
+- *Copy*: whenever you copy a file, you'll be prompted to insert the destination name. When working with multiple file, this name refers to the destination directory where all these files will be copied.
+- *Rename*: same as copy, but will move files there.
+- *Save as*: same as copy, but will write them there.
+
+### Synchronized browsing ⏲️
+
+When enabled, synchronized browsing, will allow you to synchronize the navigation between the two panels.
+This means that whenever you'll change the working directory on one panel, the same action will be reproduced on the other panel. If you want to enable synchronized browsing just press `<Y>`; press twice to disable. While enabled, the synchronized browising state will be reported on the status bar on `ON`.
+
+*Warning*: at the moment, whenever you try to access an unexisting directory, you won't be prompted to create it. This might change in a future update.
 
 ---
 

--- a/src/ui/activities/filetransfer/actions/copy.rs
+++ b/src/ui/activities/filetransfer/actions/copy.rs
@@ -41,7 +41,7 @@ impl FileTransferActivity {
                 // Reload entries
                 self.reload_local_dir();
             }
-            SelectedEntry::Multi(entries) => {
+            SelectedEntry::Many(entries) => {
                 // Try to copy each file to Input/{FILE_NAME}
                 let base_path: PathBuf = PathBuf::from(input);
                 // Iter files
@@ -68,7 +68,7 @@ impl FileTransferActivity {
                 // Reload entries
                 self.reload_remote_dir();
             }
-            SelectedEntry::Multi(entries) => {
+            SelectedEntry::Many(entries) => {
                 // Try to copy each file to Input/{FILE_NAME}
                 let base_path: PathBuf = PathBuf::from(input);
                 // Iter files

--- a/src/ui/activities/filetransfer/actions/copy.rs
+++ b/src/ui/activities/filetransfer/actions/copy.rs
@@ -26,51 +26,34 @@
  * SOFTWARE.
  */
 // locals
-use super::{FileTransferActivity, FsEntry, LogLevel};
-use std::path::PathBuf;
-use tuirealm::{Payload, Value};
+use super::{FileTransferActivity, FsEntry, LogLevel, SelectedEntry};
+use std::path::{Path, PathBuf};
 
 impl FileTransferActivity {
     /// ### action_local_copy
     ///
     /// Copy file on local
     pub(crate) fn action_local_copy(&mut self, input: String) {
-        match self.get_local_file_state() {
-            Some(Payload::One(Value::Usize(idx))) => {
+        match self.get_local_selected_entries() {
+            SelectedEntry::One(entry) => {
                 let dest_path: PathBuf = PathBuf::from(input);
-                let entry: FsEntry = self.local().get(idx).unwrap().clone();
-                match self.host.copy(&entry, dest_path.as_path()) {
-                    Ok(_) => {
-                        self.log(
-                            LogLevel::Info,
-                            format!(
-                                "Copied \"{}\" to \"{}\"",
-                                entry.get_abs_path().display(),
-                                dest_path.display()
-                            ),
-                        );
-                        // Reload entries
-                        let wrkdir: PathBuf = self.local().wrkdir.clone();
-                        self.local_scan(wrkdir.as_path());
-                    }
-                    Err(err) => self.log_and_alert(
-                        LogLevel::Error,
-                        format!(
-                            "Could not copy \"{}\" to \"{}\": {}",
-                            entry.get_abs_path().display(),
-                            dest_path.display(),
-                            err
-                        ),
-                    ),
+                self.local_copy_file(&entry, dest_path.as_path());
+                // Reload entries
+                self.reload_local_dir();
+            }
+            SelectedEntry::Multi(entries) => {
+                // Try to copy each file to Input/{FILE_NAME}
+                let base_path: PathBuf = PathBuf::from(input);
+                // Iter files
+                for entry in entries.iter() {
+                    let mut dest_path: PathBuf = base_path.clone();
+                    dest_path.push(entry.get_name());
+                    self.local_copy_file(entry, dest_path.as_path());
                 }
+                // Reload entries
+                self.reload_local_dir();
             }
-            Some(Payload::Vec(_)) => {
-                self.log_and_alert(
-                    LogLevel::Warn,
-                    format!("Copy is not supported when using seleection"),
-                );
-            }
-            _ => {}
+            SelectedEntry::None => {}
         }
     }
 
@@ -78,40 +61,74 @@ impl FileTransferActivity {
     ///
     /// Copy file on remote
     pub(crate) fn action_remote_copy(&mut self, input: String) {
-        match self.get_local_file_state() {
-            Some(Payload::One(Value::Usize(idx))) => {
+        match self.get_remote_selected_entries() {
+            SelectedEntry::One(entry) => {
                 let dest_path: PathBuf = PathBuf::from(input);
-                let entry: FsEntry = self.remote().get(idx).unwrap().clone();
-                match self.client.as_mut().copy(&entry, dest_path.as_path()) {
-                    Ok(_) => {
-                        self.log(
-                            LogLevel::Info,
-                            format!(
-                                "Copied \"{}\" to \"{}\"",
-                                entry.get_abs_path().display(),
-                                dest_path.display()
-                            ),
-                        );
-                        self.reload_remote_dir();
-                    }
-                    Err(err) => self.log_and_alert(
-                        LogLevel::Error,
-                        format!(
-                            "Could not copy \"{}\" to \"{}\": {}",
-                            entry.get_abs_path().display(),
-                            dest_path.display(),
-                            err
-                        ),
-                    ),
-                }
+                self.remote_copy_file(&entry, dest_path.as_path());
+                // Reload entries
+                self.reload_remote_dir();
             }
-            Some(Payload::Vec(_)) => {
-                self.log_and_alert(
-                    LogLevel::Warn,
-                    format!("Copy is not supported when using seleection"),
+            SelectedEntry::Multi(entries) => {
+                // Try to copy each file to Input/{FILE_NAME}
+                let base_path: PathBuf = PathBuf::from(input);
+                // Iter files
+                for entry in entries.iter() {
+                    let mut dest_path: PathBuf = base_path.clone();
+                    dest_path.push(entry.get_name());
+                    self.remote_copy_file(entry, dest_path.as_path());
+                }
+                // Reload entries
+                self.reload_remote_dir();
+            }
+            SelectedEntry::None => {}
+        }
+    }
+
+    fn local_copy_file(&mut self, entry: &FsEntry, dest: &Path) {
+        match self.host.copy(entry, dest) {
+            Ok(_) => {
+                self.log(
+                    LogLevel::Info,
+                    format!(
+                        "Copied \"{}\" to \"{}\"",
+                        entry.get_abs_path().display(),
+                        dest.display()
+                    ),
                 );
             }
-            _ => {}
+            Err(err) => self.log_and_alert(
+                LogLevel::Error,
+                format!(
+                    "Could not copy \"{}\" to \"{}\": {}",
+                    entry.get_abs_path().display(),
+                    dest.display(),
+                    err
+                ),
+            ),
+        }
+    }
+
+    fn remote_copy_file(&mut self, entry: &FsEntry, dest: &Path) {
+        match self.client.as_mut().copy(entry, dest) {
+            Ok(_) => {
+                self.log(
+                    LogLevel::Info,
+                    format!(
+                        "Copied \"{}\" to \"{}\"",
+                        entry.get_abs_path().display(),
+                        dest.display()
+                    ),
+                );
+            }
+            Err(err) => self.log_and_alert(
+                LogLevel::Error,
+                format!(
+                    "Could not copy \"{}\" to \"{}\": {}",
+                    entry.get_abs_path().display(),
+                    dest.display(),
+                    err
+                ),
+            ),
         }
     }
 }

--- a/src/ui/activities/filetransfer/actions/delete.rs
+++ b/src/ui/activities/filetransfer/actions/delete.rs
@@ -37,7 +37,7 @@ impl FileTransferActivity {
                 // Reload
                 self.reload_local_dir();
             }
-            SelectedEntry::Multi(entries) => {
+            SelectedEntry::Many(entries) => {
                 // Iter files
                 for entry in entries.iter() {
                     // Delete file
@@ -58,7 +58,7 @@ impl FileTransferActivity {
                 // Reload
                 self.reload_remote_dir();
             }
-            SelectedEntry::Multi(entries) => {
+            SelectedEntry::Many(entries) => {
                 // Iter files
                 for entry in entries.iter() {
                     // Delete file

--- a/src/ui/activities/filetransfer/actions/delete.rs
+++ b/src/ui/activities/filetransfer/actions/delete.rs
@@ -28,9 +28,21 @@
 // locals
 use super::{FileTransferActivity, FsEntry, LogLevel};
 use std::path::PathBuf;
+use tuirealm::{Payload, Value};
 
 impl FileTransferActivity {
     pub(crate) fn action_local_delete(&mut self) {
+        // Get selection
+        let selection: Vec<usize> = match self.get_local_file_state() {
+            Some(Payload::One(Value::Usize(idx))) => vec![idx],
+            Some(Payload::Vec(list)) => list.into_iter().map(|x| {
+                match x {
+                    Value::Usize(x) => x,
+                    _ => panic!("File selection contains non-usize value"),
+                }
+            }),
+
+        }
         let entry: Option<FsEntry> = self.get_local_file_entry().cloned();
         if let Some(entry) = entry {
             let full_path: PathBuf = entry.get_abs_path();
@@ -57,7 +69,7 @@ impl FileTransferActivity {
     }
 
     pub(crate) fn action_remote_delete(&mut self) {
-        if let Some(idx) = self.get_remote_file_idx() {
+        if let Some(idx) = self.get_remote_file_state() {
             // Check if file entry exists
             let entry = self.remote().get(idx).cloned();
             if let Some(entry) = entry {

--- a/src/ui/activities/filetransfer/actions/edit.rs
+++ b/src/ui/activities/filetransfer/actions/edit.rs
@@ -26,51 +26,54 @@
  * SOFTWARE.
  */
 // locals
-use super::{FileTransferActivity, FsEntry, LogLevel};
-use std::path::PathBuf;
+use super::{FileTransferActivity, FsEntry, LogLevel, SelectedEntry};
 
 impl FileTransferActivity {
     pub(crate) fn action_edit_local_file(&mut self) {
-        if self.get_local_file_entry().is_some() {
-            let fsentry: FsEntry = self.get_local_file_entry().unwrap().clone();
+        let entries: Vec<FsEntry> = match self.get_local_selected_entries() {
+            SelectedEntry::One(entry) => vec![entry],
+            SelectedEntry::Multi(entries) => entries,
+            SelectedEntry::None => vec![],
+        };
+        // Edit all entries
+        for entry in entries.iter() {
             // Check if file
-            if fsentry.is_file() {
+            if entry.is_file() {
                 self.log(
                     LogLevel::Info,
-                    format!("Opening file \"{}\"...", fsentry.get_abs_path().display()),
+                    format!("Opening file \"{}\"...", entry.get_abs_path().display()),
                 );
                 // Edit file
-                match self.edit_local_file(fsentry.get_abs_path().as_path()) {
-                    Ok(_) => {
-                        // Reload directory
-                        let pwd: PathBuf = self.local().wrkdir.clone();
-                        self.local_scan(pwd.as_path());
-                    }
-                    Err(err) => self.log_and_alert(LogLevel::Error, err),
+                if let Err(err) = self.edit_local_file(entry.get_abs_path().as_path()) {
+                    self.log_and_alert(LogLevel::Error, err);
                 }
             }
         }
+        // Reload entries
+        self.reload_local_dir();
     }
 
     pub(crate) fn action_edit_remote_file(&mut self) {
-        if self.get_remote_file_entry().is_some() {
-            let fsentry: FsEntry = self.get_remote_file_entry().unwrap().clone();
+        let entries: Vec<FsEntry> = match self.get_remote_selected_entries() {
+            SelectedEntry::One(entry) => vec![entry],
+            SelectedEntry::Multi(entries) => entries,
+            SelectedEntry::None => vec![],
+        };
+        // Edit all entries
+        for entry in entries.iter() {
             // Check if file
-            if let FsEntry::File(file) = fsentry.clone() {
+            if let FsEntry::File(file) = entry {
                 self.log(
                     LogLevel::Info,
-                    format!("Opening file \"{}\"...", fsentry.get_abs_path().display()),
+                    format!("Opening file \"{}\"...", entry.get_abs_path().display()),
                 );
                 // Edit file
-                match self.edit_remote_file(&file) {
-                    Ok(_) => {
-                        // Reload directory
-                        let pwd: PathBuf = self.remote().wrkdir.clone();
-                        self.remote_scan(pwd.as_path());
-                    }
-                    Err(err) => self.log_and_alert(LogLevel::Error, err),
+                if let Err(err) = self.edit_remote_file(&file) {
+                    self.log_and_alert(LogLevel::Error, err);
                 }
             }
         }
+        // Reload entries
+        self.reload_remote_dir();
     }
 }

--- a/src/ui/activities/filetransfer/actions/edit.rs
+++ b/src/ui/activities/filetransfer/actions/edit.rs
@@ -32,7 +32,7 @@ impl FileTransferActivity {
     pub(crate) fn action_edit_local_file(&mut self) {
         let entries: Vec<FsEntry> = match self.get_local_selected_entries() {
             SelectedEntry::One(entry) => vec![entry],
-            SelectedEntry::Multi(entries) => entries,
+            SelectedEntry::Many(entries) => entries,
             SelectedEntry::None => vec![],
         };
         // Edit all entries
@@ -56,7 +56,7 @@ impl FileTransferActivity {
     pub(crate) fn action_edit_remote_file(&mut self) {
         let entries: Vec<FsEntry> = match self.get_remote_selected_entries() {
             SelectedEntry::One(entry) => vec![entry],
-            SelectedEntry::Multi(entries) => entries,
+            SelectedEntry::Many(entries) => entries,
             SelectedEntry::None => vec![],
         };
         // Edit all entries

--- a/src/ui/activities/filetransfer/actions/exec.rs
+++ b/src/ui/activities/filetransfer/actions/exec.rs
@@ -27,7 +27,6 @@
  */
 // locals
 use super::{FileTransferActivity, LogLevel};
-use std::path::PathBuf;
 
 impl FileTransferActivity {
     pub(crate) fn action_local_exec(&mut self, input: String) {
@@ -35,8 +34,8 @@ impl FileTransferActivity {
             Ok(output) => {
                 // Reload files
                 self.log(LogLevel::Info, format!("\"{}\": {}", input, output));
-                let wrkdir: PathBuf = self.local().wrkdir.clone();
-                self.local_scan(wrkdir.as_path());
+                // Reload entries
+                self.reload_local_dir();
             }
             Err(err) => {
                 // Report err

--- a/src/ui/activities/filetransfer/actions/find.rs
+++ b/src/ui/activities/filetransfer/actions/find.rs
@@ -83,7 +83,7 @@ impl FileTransferActivity {
                     self.filetransfer_recv(&entry.get_realfile(), wrkdir.as_path(), save_as);
                 }
             },
-            SelectedEntry::Multi(entries) => {
+            SelectedEntry::Many(entries) => {
                 // In case of selection: save multiple files in wrkdir/input
                 let mut dest_path: PathBuf = wrkdir;
                 if let Some(save_as) = save_as {
@@ -119,7 +119,7 @@ impl FileTransferActivity {
                 // Delete file
                 self.remove_found_file(&entry);
             }
-            SelectedEntry::Multi(entries) => {
+            SelectedEntry::Many(entries) => {
                 // Iter files
                 for entry in entries.iter() {
                     // Delete file

--- a/src/ui/activities/filetransfer/actions/find.rs
+++ b/src/ui/activities/filetransfer/actions/find.rs
@@ -27,7 +27,7 @@
  */
 // locals
 use super::super::browser::FileExplorerTab;
-use super::{FileTransferActivity, FsEntry, LogLevel};
+use super::{FileTransferActivity, FsEntry, SelectedEntry};
 
 use std::path::PathBuf;
 
@@ -46,12 +46,12 @@ impl FileTransferActivity {
         }
     }
 
-    pub(crate) fn action_find_changedir(&mut self, idx: usize) {
+    pub(crate) fn action_find_changedir(&mut self) {
         // Match entry
-        if let Some(entry) = self.found().as_ref().unwrap().get(idx) {
+        if let SelectedEntry::One(entry) = self.get_found_selected_entries() {
             // Get path: if a directory, use directory path; if it is a File, get parent path
             let path: PathBuf = match entry {
-                FsEntry::Directory(dir) => dir.abs_path.clone(),
+                FsEntry::Directory(dir) => dir.abs_path,
                 FsEntry::File(file) => match file.abs_path.parent() {
                     None => PathBuf::from("."),
                     Some(p) => p.to_path_buf(),
@@ -69,77 +69,59 @@ impl FileTransferActivity {
         }
     }
 
-    pub(crate) fn action_find_transfer(&mut self, idx: usize, name: Option<String>) {
-        let entry: Option<FsEntry> = self.found().as_ref().unwrap().get(idx).cloned();
-        if let Some(entry) = entry {
-            // Download file
-            match self.browser.tab() {
+    pub(crate) fn action_find_transfer(&mut self, save_as: Option<String>) {
+        let wrkdir: PathBuf = match self.browser.tab() {
+            FileExplorerTab::FindLocal | FileExplorerTab::Local => self.remote().wrkdir.clone(),
+            FileExplorerTab::FindRemote | FileExplorerTab::Remote => self.local().wrkdir.clone(),
+        };
+        match self.get_found_selected_entries() {
+            SelectedEntry::One(entry) => match self.browser.tab() {
                 FileExplorerTab::FindLocal | FileExplorerTab::Local => {
-                    let wrkdir: PathBuf = self.remote().wrkdir.clone();
-                    self.filetransfer_send(&entry.get_realfile(), wrkdir.as_path(), name);
+                    self.filetransfer_send(&entry.get_realfile(), wrkdir.as_path(), save_as);
                 }
                 FileExplorerTab::FindRemote | FileExplorerTab::Remote => {
-                    let wrkdir: PathBuf = self.local().wrkdir.clone();
-                    self.filetransfer_recv(&entry.get_realfile(), wrkdir.as_path(), name);
+                    self.filetransfer_recv(&entry.get_realfile(), wrkdir.as_path(), save_as);
+                }
+            },
+            SelectedEntry::Multi(entries) => {
+                // In case of selection: save multiple files in wrkdir/input
+                let mut dest_path: PathBuf = wrkdir;
+                if let Some(save_as) = save_as {
+                    dest_path.push(save_as);
+                }
+                // Iter files
+                for entry in entries.iter() {
+                    self.filetransfer_recv(&entry.get_realfile(), dest_path.as_path(), None);
                 }
             }
+            SelectedEntry::None => {}
         }
     }
 
-    pub(crate) fn action_find_delete(&mut self, idx: usize) {
-        let entry: Option<FsEntry> = self.found().as_ref().unwrap().get(idx).cloned();
-        if let Some(entry) = entry {
-            // Download file
-            match self.browser.tab() {
-                FileExplorerTab::FindLocal | FileExplorerTab::Local => {
-                    let full_path: PathBuf = entry.get_abs_path();
-                    // Delete file or directory and report status as popup
-                    match self.host.remove(&entry) {
-                        Ok(_) => {
-                            // Reload files
-                            let p: PathBuf = self.local().wrkdir.clone();
-                            self.local_scan(p.as_path());
-                            // Log
-                            self.log(
-                                LogLevel::Info,
-                                format!("Removed file \"{}\"", full_path.display()),
-                            );
-                        }
-                        Err(err) => {
-                            self.log_and_alert(
-                                LogLevel::Error,
-                                format!(
-                                    "Could not delete file \"{}\": {}",
-                                    full_path.display(),
-                                    err
-                                ),
-                            );
-                        }
-                    }
-                }
-                FileExplorerTab::FindRemote | FileExplorerTab::Remote => {
-                    let full_path: PathBuf = entry.get_abs_path();
+    pub(crate) fn action_find_delete(&mut self) {
+        match self.get_found_selected_entries() {
+            SelectedEntry::One(entry) => {
+                // Delete file
+                self.remove_found_file(&entry);
+            }
+            SelectedEntry::Multi(entries) => {
+                // Iter files
+                for entry in entries.iter() {
                     // Delete file
-                    match self.client.remove(&entry) {
-                        Ok(_) => {
-                            self.reload_remote_dir();
-                            self.log(
-                                LogLevel::Info,
-                                format!("Removed file \"{}\"", full_path.display()),
-                            );
-                        }
-                        Err(err) => {
-                            self.log_and_alert(
-                                LogLevel::Error,
-                                format!(
-                                    "Could not delete file \"{}\": {}",
-                                    full_path.display(),
-                                    err
-                                ),
-                            );
-                        }
-                    }
+                    self.remove_found_file(entry);
                 }
+            }
+            SelectedEntry::None => {}
+        }
+    }
+
+    fn remove_found_file(&mut self, entry: &FsEntry) {
+        match self.browser.tab() {
+            FileExplorerTab::FindLocal | FileExplorerTab::Local => {
+                self.local_remove_file(entry);
+            }
+            FileExplorerTab::FindRemote | FileExplorerTab::Remote => {
+                self.remote_remove_file(entry);
             }
         }
     }

--- a/src/ui/activities/filetransfer/actions/find.rs
+++ b/src/ui/activities/filetransfer/actions/find.rs
@@ -91,7 +91,22 @@ impl FileTransferActivity {
                 }
                 // Iter files
                 for entry in entries.iter() {
-                    self.filetransfer_recv(&entry.get_realfile(), dest_path.as_path(), None);
+                    match self.browser.tab() {
+                        FileExplorerTab::FindLocal | FileExplorerTab::Local => {
+                            self.filetransfer_send(
+                                &entry.get_realfile(),
+                                dest_path.as_path(),
+                                None,
+                            );
+                        }
+                        FileExplorerTab::FindRemote | FileExplorerTab::Remote => {
+                            self.filetransfer_recv(
+                                &entry.get_realfile(),
+                                dest_path.as_path(),
+                                None,
+                            );
+                        }
+                    }
                 }
             }
             SelectedEntry::None => {}

--- a/src/ui/activities/filetransfer/actions/mkdir.rs
+++ b/src/ui/activities/filetransfer/actions/mkdir.rs
@@ -35,8 +35,8 @@ impl FileTransferActivity {
             Ok(_) => {
                 // Reload files
                 self.log(LogLevel::Info, format!("Created directory \"{}\"", input));
-                let wrkdir: PathBuf = self.local().wrkdir.clone();
-                self.local_scan(wrkdir.as_path());
+                // Reload entries
+                self.reload_local_dir();
             }
             Err(err) => {
                 // Report err

--- a/src/ui/activities/filetransfer/actions/mod.rs
+++ b/src/ui/activities/filetransfer/actions/mod.rs
@@ -45,9 +45,9 @@ impl FileTransferActivity {
     ///
     /// Get local file entry
     pub(crate) fn get_local_file_entry(&self) -> Option<&FsEntry> {
-        match self.get_local_file_idx() {
-            None => None,
-            Some(idx) => self.local().get(idx),
+        match self.get_local_file_state() {
+            Some(Payload::One(Value::Usize(idx))) => self.local().get(idx),
+            _ => None,
         }
     }
 
@@ -55,31 +55,25 @@ impl FileTransferActivity {
     ///
     /// Get remote file entry
     pub(crate) fn get_remote_file_entry(&self) -> Option<&FsEntry> {
-        match self.get_remote_file_idx() {
-            None => None,
-            Some(idx) => self.remote().get(idx),
+        match self.get_remote_file_state() {
+            Some(Payload::One(Value::Usize(idx))) => self.remote().get(idx),
+            _ => None,
         }
     }
 
     // -- private
 
-    /// ### get_local_file_idx
+    /// ### get_local_file_state
     ///
     /// Get index of selected file in the local tab
-    fn get_local_file_idx(&self) -> Option<usize> {
-        match self.view.get_state(super::COMPONENT_EXPLORER_LOCAL) {
-            Some(Payload::One(Value::Usize(idx))) => Some(idx),
-            _ => None,
-        }
+    fn get_local_file_state(&self) -> Option<Payload> {
+        self.view.get_state(super::COMPONENT_EXPLORER_LOCAL)
     }
 
-    /// ### get_remote_file_idx
+    /// ### get_remote_file_state
     ///
     /// Get index of selected file in the remote file
-    fn get_remote_file_idx(&self) -> Option<usize> {
-        match self.view.get_state(super::COMPONENT_EXPLORER_REMOTE) {
-            Some(Payload::One(Value::Usize(idx))) => Some(idx),
-            _ => None,
-        }
+    fn get_remote_file_state(&self) -> Option<Payload> {
+        self.view.get_state(super::COMPONENT_EXPLORER_REMOTE)
     }
 }

--- a/src/ui/activities/filetransfer/actions/mod.rs
+++ b/src/ui/activities/filetransfer/actions/mod.rs
@@ -42,13 +42,13 @@ pub(crate) mod save;
 
 pub(crate) enum SelectedEntry {
     One(FsEntry),
-    Multi(Vec<FsEntry>),
+    Many(Vec<FsEntry>),
     None,
 }
 
 enum SelectedEntryIndex {
     One(usize),
-    Multi(Vec<usize>),
+    Many(Vec<usize>),
     None,
 }
 
@@ -63,7 +63,7 @@ impl From<Option<&FsEntry>> for SelectedEntry {
 
 impl From<Vec<&FsEntry>> for SelectedEntry {
     fn from(files: Vec<&FsEntry>) -> Self {
-        SelectedEntry::Multi(files.into_iter().cloned().collect())
+        SelectedEntry::Many(files.into_iter().cloned().collect())
     }
 }
 
@@ -74,7 +74,7 @@ impl FileTransferActivity {
     pub(crate) fn get_local_selected_entries(&self) -> SelectedEntry {
         match self.get_selected_index(super::COMPONENT_EXPLORER_LOCAL) {
             SelectedEntryIndex::One(idx) => SelectedEntry::from(self.local().get(idx)),
-            SelectedEntryIndex::Multi(files) => {
+            SelectedEntryIndex::Many(files) => {
                 let files: Vec<&FsEntry> = files
                     .iter()
                     .map(|x| self.local().get(*x)) // Usize to Option<FsEntry>
@@ -93,7 +93,7 @@ impl FileTransferActivity {
     pub(crate) fn get_remote_selected_entries(&self) -> SelectedEntry {
         match self.get_selected_index(super::COMPONENT_EXPLORER_REMOTE) {
             SelectedEntryIndex::One(idx) => SelectedEntry::from(self.remote().get(idx)),
-            SelectedEntryIndex::Multi(files) => {
+            SelectedEntryIndex::Many(files) => {
                 let files: Vec<&FsEntry> = files
                     .iter()
                     .map(|x| self.remote().get(*x)) // Usize to Option<FsEntry>
@@ -114,7 +114,7 @@ impl FileTransferActivity {
             SelectedEntryIndex::One(idx) => {
                 SelectedEntry::from(self.found().as_ref().unwrap().get(idx))
             }
-            SelectedEntryIndex::Multi(files) => {
+            SelectedEntryIndex::Many(files) => {
                 let files: Vec<&FsEntry> = files
                     .iter()
                     .map(|x| self.found().as_ref().unwrap().get(*x)) // Usize to Option<FsEntry>
@@ -140,7 +140,7 @@ impl FileTransferActivity {
                         _ => 0,
                     })
                     .collect();
-                SelectedEntryIndex::Multi(list)
+                SelectedEntryIndex::Many(list)
             }
             _ => SelectedEntryIndex::None,
         }

--- a/src/ui/activities/filetransfer/actions/mod.rs
+++ b/src/ui/activities/filetransfer/actions/mod.rs
@@ -40,40 +40,114 @@ pub(crate) mod newfile;
 pub(crate) mod rename;
 pub(crate) mod save;
 
+pub(crate) enum SelectedEntry {
+    One(FsEntry),
+    Multi(Vec<FsEntry>),
+    None,
+}
+
+enum SelectedEntryIndex {
+    One(usize),
+    Multi(Vec<usize>),
+    None,
+}
+
+impl From<Option<&FsEntry>> for SelectedEntry {
+    fn from(opt: Option<&FsEntry>) -> Self {
+        match opt {
+            Some(e) => SelectedEntry::One(e.clone()),
+            None => SelectedEntry::None,
+        }
+    }
+}
+
+impl From<Vec<&FsEntry>> for SelectedEntry {
+    fn from(files: Vec<&FsEntry>) -> Self {
+        SelectedEntry::Multi(files.into_iter().cloned().collect())
+    }
+}
+
 impl FileTransferActivity {
-    /// ### get_local_file_entry
+    /// ### get_local_selected_entries
     ///
     /// Get local file entry
-    pub(crate) fn get_local_file_entry(&self) -> Option<&FsEntry> {
-        match self.get_local_file_state() {
-            Some(Payload::One(Value::Usize(idx))) => self.local().get(idx),
-            _ => None,
+    pub(crate) fn get_local_selected_entries(&self) -> SelectedEntry {
+        match self.get_selected_index(super::COMPONENT_EXPLORER_LOCAL) {
+            SelectedEntryIndex::One(idx) => SelectedEntry::from(self.local().get(idx)),
+            SelectedEntryIndex::Multi(files) => {
+                let files: Vec<&FsEntry> = files
+                    .iter()
+                    .map(|x| self.local().get(*x)) // Usize to Option<FsEntry>
+                    .filter(|x| x.is_some()) // Get only some values
+                    .map(|x| x.unwrap()) // Option to FsEntry
+                    .collect();
+                SelectedEntry::from(files)
+            }
+            SelectedEntryIndex::None => SelectedEntry::None,
         }
     }
 
-    /// ### get_remote_file_entry
+    /// ### get_remote_selected_entries
     ///
     /// Get remote file entry
-    pub(crate) fn get_remote_file_entry(&self) -> Option<&FsEntry> {
-        match self.get_remote_file_state() {
-            Some(Payload::One(Value::Usize(idx))) => self.remote().get(idx),
-            _ => None,
+    pub(crate) fn get_remote_selected_entries(&self) -> SelectedEntry {
+        match self.get_selected_index(super::COMPONENT_EXPLORER_REMOTE) {
+            SelectedEntryIndex::One(idx) => SelectedEntry::from(self.remote().get(idx)),
+            SelectedEntryIndex::Multi(files) => {
+                let files: Vec<&FsEntry> = files
+                    .iter()
+                    .map(|x| self.remote().get(*x)) // Usize to Option<FsEntry>
+                    .filter(|x| x.is_some()) // Get only some values
+                    .map(|x| x.unwrap()) // Option to FsEntry
+                    .collect();
+                SelectedEntry::from(files)
+            }
+            SelectedEntryIndex::None => SelectedEntry::None,
+        }
+    }
+
+    /// ### get_remote_selected_entries
+    ///
+    /// Get remote file entry
+    pub(crate) fn get_found_selected_entries(&self) -> SelectedEntry {
+        match self.get_selected_index(super::COMPONENT_EXPLORER_FIND) {
+            SelectedEntryIndex::One(idx) => {
+                SelectedEntry::from(self.found().as_ref().unwrap().get(idx))
+            }
+            SelectedEntryIndex::Multi(files) => {
+                let files: Vec<&FsEntry> = files
+                    .iter()
+                    .map(|x| self.found().as_ref().unwrap().get(*x)) // Usize to Option<FsEntry>
+                    .filter(|x| x.is_some()) // Get only some values
+                    .map(|x| x.unwrap()) // Option to FsEntry
+                    .collect();
+                SelectedEntry::from(files)
+            }
+            SelectedEntryIndex::None => SelectedEntry::None,
         }
     }
 
     // -- private
 
-    /// ### get_local_file_state
-    ///
-    /// Get index of selected file in the local tab
-    fn get_local_file_state(&self) -> Option<Payload> {
-        self.view.get_state(super::COMPONENT_EXPLORER_LOCAL)
-    }
-
-    /// ### get_remote_file_state
-    ///
-    /// Get index of selected file in the remote file
-    fn get_remote_file_state(&self) -> Option<Payload> {
-        self.view.get_state(super::COMPONENT_EXPLORER_REMOTE)
+    fn get_selected_index(&self, component: &str) -> SelectedEntryIndex {
+        eprintln!(
+            "INDEX FOR {}: {:?}",
+            component,
+            self.view.get_state(component)
+        );
+        match self.view.get_state(component) {
+            Some(Payload::One(Value::Usize(idx))) => SelectedEntryIndex::One(idx),
+            Some(Payload::Vec(files)) => {
+                let list: Vec<usize> = files
+                    .iter()
+                    .map(|x| match x {
+                        Value::Usize(v) => *v,
+                        _ => 0,
+                    })
+                    .collect();
+                SelectedEntryIndex::Multi(list)
+            }
+            _ => SelectedEntryIndex::None,
+        }
     }
 }

--- a/src/ui/activities/filetransfer/actions/mod.rs
+++ b/src/ui/activities/filetransfer/actions/mod.rs
@@ -130,11 +130,6 @@ impl FileTransferActivity {
     // -- private
 
     fn get_selected_index(&self, component: &str) -> SelectedEntryIndex {
-        eprintln!(
-            "INDEX FOR {}: {:?}",
-            component,
-            self.view.get_state(component)
-        );
         match self.view.get_state(component) {
             Some(Payload::One(Value::Usize(idx))) => SelectedEntryIndex::One(idx),
             Some(Payload::Vec(files)) => {

--- a/src/ui/activities/filetransfer/actions/newfile.rs
+++ b/src/ui/activities/filetransfer/actions/newfile.rs
@@ -59,8 +59,7 @@ impl FileTransferActivity {
             );
         }
         // Reload files
-        let path: PathBuf = self.local().wrkdir.clone();
-        self.local_scan(path.as_path());
+        self.reload_local_dir();
     }
 
     pub(crate) fn action_remote_newfile(&mut self, input: String) {
@@ -119,8 +118,7 @@ impl FileTransferActivity {
                                 );
                             }
                             // Reload files
-                            let path: PathBuf = self.remote().wrkdir.clone();
-                            self.remote_scan(path.as_path());
+                            self.reload_remote_dir();
                         }
                     }
                 }

--- a/src/ui/activities/filetransfer/actions/rename.rs
+++ b/src/ui/activities/filetransfer/actions/rename.rs
@@ -68,7 +68,7 @@ impl FileTransferActivity {
     }
 
     pub(crate) fn action_remote_rename(&mut self, input: String) {
-        if let Some(idx) = self.get_remote_file_idx() {
+        if let Some(idx) = self.get_remote_file_state() {
             let entry = self.remote().get(idx).cloned();
             if let Some(entry) = entry {
                 let dst_path: PathBuf = PathBuf::from(input);

--- a/src/ui/activities/filetransfer/actions/rename.rs
+++ b/src/ui/activities/filetransfer/actions/rename.rs
@@ -38,7 +38,7 @@ impl FileTransferActivity {
                 // Reload entries
                 self.reload_local_dir();
             }
-            SelectedEntry::Multi(entries) => {
+            SelectedEntry::Many(entries) => {
                 // Try to copy each file to Input/{FILE_NAME}
                 let base_path: PathBuf = PathBuf::from(input);
                 // Iter files
@@ -62,7 +62,7 @@ impl FileTransferActivity {
                 // Reload entries
                 self.reload_remote_dir();
             }
-            SelectedEntry::Multi(entries) => {
+            SelectedEntry::Many(entries) => {
                 // Try to copy each file to Input/{FILE_NAME}
                 let base_path: PathBuf = PathBuf::from(input);
                 // Iter files

--- a/src/ui/activities/filetransfer/actions/save.rs
+++ b/src/ui/activities/filetransfer/actions/save.rs
@@ -52,7 +52,7 @@ impl FileTransferActivity {
             SelectedEntry::One(entry) => {
                 self.filetransfer_send(&entry.get_realfile(), wrkdir.as_path(), save_as);
             }
-            SelectedEntry::Multi(entries) => {
+            SelectedEntry::Many(entries) => {
                 // In case of selection: save multiple files in wrkdir/input
                 let mut dest_path: PathBuf = wrkdir;
                 if let Some(save_as) = save_as {
@@ -73,7 +73,7 @@ impl FileTransferActivity {
             SelectedEntry::One(entry) => {
                 self.filetransfer_recv(&entry.get_realfile(), wrkdir.as_path(), save_as);
             }
-            SelectedEntry::Multi(entries) => {
+            SelectedEntry::Many(entries) => {
                 // In case of selection: save multiple files in wrkdir/input
                 let mut dest_path: PathBuf = wrkdir;
                 if let Some(save_as) = save_as {

--- a/src/ui/activities/filetransfer/actions/save.rs
+++ b/src/ui/activities/filetransfer/actions/save.rs
@@ -31,7 +31,7 @@ use std::path::PathBuf;
 
 impl FileTransferActivity {
     pub(crate) fn action_local_saveas(&mut self, input: String) {
-        if let Some(idx) = self.get_local_file_idx() {
+        if let Some(idx) = self.get_local_file_state() {
             // Get pwd
             let wrkdir: PathBuf = self.remote().wrkdir.clone();
             if self.local().get(idx).is_some() {
@@ -43,7 +43,7 @@ impl FileTransferActivity {
     }
 
     pub(crate) fn action_remote_saveas(&mut self, input: String) {
-        if let Some(idx) = self.get_remote_file_idx() {
+        if let Some(idx) = self.get_remote_file_state() {
             // Get pwd
             let wrkdir: PathBuf = self.local().wrkdir.clone();
             if self.remote().get(idx).is_some() {

--- a/src/ui/activities/filetransfer/session.rs
+++ b/src/ui/activities/filetransfer/session.rs
@@ -145,6 +145,11 @@ impl FileTransferActivity {
         }
     }
 
+    pub(super) fn reload_local_dir(&mut self) {
+        let wrkdir: PathBuf = self.local().wrkdir.clone();
+        self.local_scan(wrkdir.as_path());
+    }
+
     /// ### filetransfer_send
     ///
     /// Send fs entry to remote.
@@ -257,8 +262,7 @@ impl FileTransferActivity {
             }
         }
         // Scan dir on remote
-        let path: PathBuf = self.remote().wrkdir.clone();
-        self.remote_scan(path.as_path());
+        self.reload_remote_dir();
         // If aborted; show popup
         if self.transfer.aborted {
             // Log abort

--- a/src/ui/activities/filetransfer/update.rs
+++ b/src/ui/activities/filetransfer/update.rs
@@ -546,14 +546,25 @@ impl FileTransferActivity {
                         FileExplorerTab::Remote => self.action_remote_delete(),
                         FileExplorerTab::FindLocal | FileExplorerTab::FindRemote => {
                             // Get entry
-                            if let Some(Payload::One(Value::Usize(idx))) =
-                                self.view.get_state(COMPONENT_EXPLORER_FIND)
-                            {
-                                self.action_find_delete();
-                                // Reload entries
-                                self.found_mut().unwrap().del_entry(idx);
-                                self.update_find_list();
+                            self.action_find_delete();
+                            // Delete entries
+                            match self.view.get_state(COMPONENT_EXPLORER_FIND) {
+                                Some(Payload::One(Value::Usize(idx))) => {
+                                    // Reload entries
+                                    self.found_mut().unwrap().del_entry(idx);
+                                }
+                                Some(Payload::Vec(values)) => {
+                                    values
+                                        .iter()
+                                        .map(|x| match x {
+                                            Value::Usize(v) => *v,
+                                            _ => 0,
+                                        })
+                                        .for_each(|x| self.found_mut().unwrap().del_entry(x));
+                                }
+                                _ => {}
                             }
+                            self.update_find_list();
                         }
                     }
                     self.umount_radio_delete();

--- a/src/ui/activities/filetransfer/view.rs
+++ b/src/ui/activities/filetransfer/view.rs
@@ -976,6 +976,14 @@ impl FileTransferActivity {
                             .add_col(TextSpan::from("             Reload directory content"))
                             .add_row()
                             .add_col(
+                                TextSpanBuilder::new("<M>")
+                                    .bold()
+                                    .with_foreground(Color::Cyan)
+                                    .build(),
+                            )
+                            .add_col(TextSpan::from("             Select file"))
+                            .add_row()
+                            .add_col(
                                 TextSpanBuilder::new("<N>")
                                     .bold()
                                     .with_foreground(Color::Cyan)
@@ -1046,6 +1054,14 @@ impl FileTransferActivity {
                                     .build(),
                             )
                             .add_col(TextSpan::from("         Delete selected file"))
+                            .add_row()
+                            .add_col(
+                                TextSpanBuilder::new("<CTRL+A>")
+                                    .bold()
+                                    .with_foreground(Color::Cyan)
+                                    .build(),
+                            )
+                            .add_col(TextSpan::from("        Select all files"))
                             .add_row()
                             .add_col(
                                 TextSpanBuilder::new("<CTRL+C>")

--- a/src/ui/components/file_list.rs
+++ b/src/ui/components/file_list.rs
@@ -386,7 +386,7 @@ impl Component for FileList {
                         self.states.select_all();
                         Msg::None
                     }
-                    false => Msg::None,
+                    false => Msg::OnKey(key),
                 },
                 KeyCode::Char('m') => {
                     // Toggle current file in selection
@@ -620,6 +620,11 @@ mod tests {
         assert_eq!(
             component.on(Event::Key(KeyEvent::from(KeyCode::Backspace))),
             Msg::OnKey(KeyEvent::from(KeyCode::Backspace))
+        );
+        // Verify 'A' still works
+        assert_eq!(
+            component.on(Event::Key(KeyEvent::from(KeyCode::Char('a')))),
+            Msg::OnKey(KeyEvent::from(KeyCode::Char('a')))
         );
     }
 

--- a/src/ui/components/file_list.rs
+++ b/src/ui/components/file_list.rs
@@ -380,7 +380,7 @@ impl Component for FileList {
                     Msg::None
                 }
                 KeyCode::Char('a') => match key.modifiers.intersects(KeyModifiers::CONTROL) {
-                    // CTRL+C
+                    // CTRL+A
                     true => {
                         // Select all
                         self.states.select_all();


### PR DESCRIPTION
# File group select

## Description

This PR adds the possilbity to operate on a group selection of files in explorers.

The implementation consists in:

- adding a combo key to push a file into the selection
- In actions iter over selection, instead of operating on one file
- File list now returns a list instead of an index if a selection is active, otherwise the highlighted element.

### Select Behaviour

- If selection is empty, file list returns highlighted item as `One(Value::Usize)`
- If selection is not empty, file list returns  `Vec(Value::Usize)`with selected items
- Update clears the current selection
- If the user presses `<CTRL+A>` all elements get selected
- if the user presses `<M>` the item is pushed or popped to/from selection
- if the user presses `<L>` the selection is cleared

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit
