### PR TITLE
Help panels as ScrollTable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,9 +24,10 @@ Released on FIXME: ??
 
 - Bugfix:
   - Fixed broken input cursor when typing UTF8 characters (tui-realm 0.3.2)
+  - Help panels as `ScrollTable` to allow displaying entire content on small screens
 - Dependencies:
   - Updated `textwrap` to `0.14.0`
-  - Updated `tui-realm` to `0.4.1`
+  - Updated `tui-realm` to `0.4.2`
 
 ## 0.5.0
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1440,9 +1440,9 @@ dependencies = [
 
 [[package]]
 name = "tuirealm"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bee2a1c050878fac02ba3a6c2e93aa92a1de56849d5deec00d4ab4bc7928c0a"
+checksum = "9897335542e4a4a87ad391419c35e54b4088661e671ba53e578fbbb1154740c2"
 dependencies = [
  "crossterm",
  "textwrap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,7 +50,7 @@ tempfile = "3.1.0"
 textwrap = "0.14.0"
 thiserror = "^1.0.0"
 toml = "0.5.8"
-tuirealm = { version = "0.4.1", features = [ "with-components" ] }
+tuirealm = { version = "0.4.2", features = [ "with-components" ] }
 ureq = { version = "2.1.0", features = [ "json" ] }
 whoami = "1.1.1"
 wildmatch = "2.0.0"

--- a/src/ui/activities/auth/view.rs
+++ b/src/ui/activities/auth/view.rs
@@ -37,8 +37,8 @@ use tuirealm::components::{
     input::{Input, InputPropsBuilder},
     label::{Label, LabelPropsBuilder},
     radio::{Radio, RadioPropsBuilder},
+    scrolltable::{ScrollTablePropsBuilder, Scrolltable},
     span::{Span, SpanPropsBuilder},
-    table::{Table, TablePropsBuilder},
 };
 use tuirealm::tui::{
     layout::{Constraint, Direction, Layout},
@@ -622,9 +622,12 @@ impl AuthActivity {
     pub(super) fn mount_help(&mut self) {
         self.view.mount(
             super::COMPONENT_TEXT_HELP,
-            Box::new(Table::new(
-                TablePropsBuilder::default()
+            Box::new(Scrolltable::new(
+                ScrollTablePropsBuilder::default()
                     .with_borders(Borders::ALL, BorderType::Rounded, Color::White)
+                    .with_highlighted_str(Some("?"))
+                    .with_max_scroll_step(8)
+                    .bold()
                     .with_table(
                         Some(String::from("Help")),
                         TableBuilder::default()

--- a/src/ui/activities/filetransfer/view.rs
+++ b/src/ui/activities/filetransfer/view.rs
@@ -49,6 +49,7 @@ use tuirealm::components::{
     input::{Input, InputPropsBuilder},
     progress_bar::{ProgressBar, ProgressBarPropsBuilder},
     radio::{Radio, RadioPropsBuilder},
+    scrolltable::{ScrollTablePropsBuilder, Scrolltable},
     span::{Span, SpanPropsBuilder},
     table::{Table, TablePropsBuilder},
 };
@@ -880,9 +881,12 @@ impl FileTransferActivity {
     pub(super) fn mount_help(&mut self) {
         self.view.mount(
             super::COMPONENT_TEXT_HELP,
-            Box::new(Table::new(
-                TablePropsBuilder::default()
+            Box::new(Scrolltable::new(
+                ScrollTablePropsBuilder::default()
                     .with_borders(Borders::ALL, BorderType::Rounded, Color::White)
+                    .with_highlighted_str(Some("?"))
+                    .with_max_scroll_step(8)
+                    .bold()
                     .with_table(
                         Some(String::from("Help")),
                         TableBuilder::default()

--- a/src/ui/activities/setup/view.rs
+++ b/src/ui/activities/setup/view.rs
@@ -40,8 +40,8 @@ use std::path::PathBuf;
 use tuirealm::components::{
     input::{Input, InputPropsBuilder},
     radio::{Radio, RadioPropsBuilder},
+    scrolltable::{ScrollTablePropsBuilder, Scrolltable},
     span::{Span, SpanPropsBuilder},
-    table::{Table, TablePropsBuilder},
 };
 use tuirealm::tui::{
     layout::{Constraint, Direction, Layout},
@@ -557,9 +557,12 @@ impl SetupActivity {
     pub(super) fn mount_help(&mut self) {
         self.view.mount(
             super::COMPONENT_TEXT_HELP,
-            Box::new(Table::new(
-                TablePropsBuilder::default()
+            Box::new(Scrolltable::new(
+                ScrollTablePropsBuilder::default()
                     .with_borders(Borders::ALL, BorderType::Rounded, Color::White)
+                    .with_highlighted_str(Some("?"))
+                    .with_max_scroll_step(8)
+                    .bold()
                     .with_table(
                         Some(String::from("Help")),
                         TableBuilder::default()


### PR DESCRIPTION
#39  - Help panels as scroll tables

Fixes #39 

## Description

- Changed help panel components to `Scrolltable` in order to allow scrolling.
- tui-realm 0.4.2

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
