### PR TITLE
Fixed progress bar not visible when editing remote files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ Released on FIXME: ??
 
 - Bugfix:
   - Fixed broken input cursor when typing UTF8 characters (tui-realm 0.3.2)
-  - Help panels as `ScrollTable` to allow displaying entire content on small screens
+  - Fixed [Issue 39](https://github.com/veeso/termscp/issues/39): Help panels as `ScrollTable` to allow displaying entire content on small screens
+  - Fixed [Issue 37](https://github.com/veeso/termscp/issues/37): progress bar not visible when editing remote files
 - Dependencies:
   - Updated `textwrap` to `0.14.0`
   - Updated `tui-realm` to `0.4.2`

--- a/src/ui/activities/filetransfer/actions/copy.rs
+++ b/src/ui/activities/filetransfer/actions/copy.rs
@@ -139,4 +139,111 @@ impl FileTransferActivity {
             },
         }
     }
+
+    /// ### tricky_copy
+    ///
+    /// Tricky copy will be used whenever copy command is not available on remote host
+    fn tricky_copy(&mut self, entry: &FsEntry, dest: &Path) {
+        // match entry
+        match entry {
+            FsEntry::File(entry) => {
+                // Create tempfile
+                let tmpfile: tempfile::NamedTempFile = match tempfile::NamedTempFile::new() {
+                    Ok(f) => f,
+                    Err(err) => {
+                        self.log_and_alert(
+                            LogLevel::Error,
+                            format!("Copy failed: could not create temporary file: {}", err),
+                        );
+                        return;
+                    }
+                };
+                // Download file
+                if let Err(err) =
+                    self.filetransfer_recv_one(entry, tmpfile.path(), entry.name.clone())
+                {
+                    self.log_and_alert(
+                        LogLevel::Error,
+                        format!("Copy failed: could not download to temporary file: {}", err),
+                    );
+                    return;
+                }
+                // Get local fs entry
+                let tmpfile_entry: FsEntry = match self.host.stat(tmpfile.path()) {
+                    Ok(e) => e,
+                    Err(err) => {
+                        self.log_and_alert(
+                            LogLevel::Error,
+                            format!(
+                                "Copy failed: could not stat \"{}\": {}",
+                                tmpfile.path().display(),
+                                err
+                            ),
+                        );
+                        return;
+                    }
+                };
+                let tmpfile_entry = match &tmpfile_entry {
+                    FsEntry::Directory(_) => panic!("tempfile is a directory for some reason"),
+                    FsEntry::File(f) => f,
+                };
+                // Upload file to destination
+                let wrkdir = self.remote().wrkdir.clone();
+                if let Err(err) = self.filetransfer_send_one(
+                    tmpfile_entry,
+                    wrkdir.as_path(),
+                    Some(String::from(dest.to_string_lossy())),
+                ) {
+                    self.log_and_alert(
+                        LogLevel::Error,
+                        format!(
+                            "Copy failed: could not write file {}: {}",
+                            entry.abs_path.display(),
+                            err
+                        ),
+                    );
+                    return;
+                }
+            }
+            FsEntry::Directory(_) => {
+                let tempdir: tempfile::TempDir = match tempfile::TempDir::new() {
+                    Ok(d) => d,
+                    Err(err) => {
+                        self.log_and_alert(
+                            LogLevel::Error,
+                            format!("Copy failed: could not create temporary directory: {}", err),
+                        );
+                        return;
+                    }
+                };
+                // Download file
+                self.filetransfer_recv(entry, tempdir.path(), None);
+                // Get path of dest
+                let mut tempdir_path: PathBuf = tempdir.path().to_path_buf();
+                tempdir_path.push(entry.get_name());
+                // Stat dir
+                let tempdir_entry: FsEntry = match self.host.stat(tempdir_path.as_path()) {
+                    Ok(e) => e,
+                    Err(err) => {
+                        self.log_and_alert(
+                            LogLevel::Error,
+                            format!(
+                                "Copy failed: could not stat \"{}\": {}",
+                                tempdir.path().display(),
+                                err
+                            ),
+                        );
+                        return;
+                    }
+                };
+                // Upload to destination
+                let wrkdir: PathBuf = self.remote().wrkdir.clone();
+                self.filetransfer_send(
+                    &tempdir_entry,
+                    wrkdir.as_path(),
+                    Some(String::from(dest.to_string_lossy())),
+                );
+            }
+        }
+    }
 }

--- a/src/ui/activities/filetransfer/actions/edit.rs
+++ b/src/ui/activities/filetransfer/actions/edit.rs
@@ -27,6 +27,13 @@
  */
 // locals
 use super::{FileTransferActivity, FsEntry, LogLevel, SelectedEntry};
+use crate::fs::FsFile;
+// ext
+use crossterm::terminal::{disable_raw_mode, enable_raw_mode};
+use std::fs::OpenOptions;
+use std::io::Read;
+use std::path::Path;
+use std::time::SystemTime;
 
 impl FileTransferActivity {
     pub(crate) fn action_edit_local_file(&mut self) {
@@ -75,5 +82,150 @@ impl FileTransferActivity {
         }
         // Reload entries
         self.reload_remote_dir();
+    }
+
+    /// ### edit_local_file
+    ///
+    /// Edit a file on localhost
+    fn edit_local_file(&mut self, path: &Path) -> Result<(), String> {
+        // Read first 2048 bytes or less from file to check if it is textual
+        match OpenOptions::new().read(true).open(path) {
+            Ok(mut f) => {
+                // Read
+                let mut buff: [u8; 2048] = [0; 2048];
+                match f.read(&mut buff) {
+                    Ok(size) => {
+                        if content_inspector::inspect(&buff[0..size]).is_binary() {
+                            return Err("Could not open file in editor: file is binary".to_string());
+                        }
+                    }
+                    Err(err) => {
+                        return Err(format!("Could not read file: {}", err));
+                    }
+                }
+            }
+            Err(err) => {
+                return Err(format!("Could not read file: {}", err));
+            }
+        }
+        // Put input mode back to normal
+        if let Err(err) = disable_raw_mode() {
+            error!("Failed to disable raw mode: {}", err);
+        }
+        // Leave alternate mode
+        if let Some(ctx) = self.context.as_mut() {
+            ctx.leave_alternate_screen();
+        }
+        // Open editor
+        match edit::edit_file(path) {
+            Ok(_) => self.log(
+                LogLevel::Info,
+                format!(
+                    "Changes performed through editor saved to \"{}\"!",
+                    path.display()
+                ),
+            ),
+            Err(err) => return Err(format!("Could not open editor: {}", err)),
+        }
+        if let Some(ctx) = self.context.as_mut() {
+            // Clear screen
+            ctx.clear_screen();
+            // Enter alternate mode
+            ctx.enter_alternate_screen();
+        }
+        // Re-enable raw mode
+        let _ = enable_raw_mode();
+        Ok(())
+    }
+
+    /// ### edit_remote_file
+    ///
+    /// Edit file on remote host
+    fn edit_remote_file(&mut self, file: &FsFile) -> Result<(), String> {
+        // Create temp file
+        let tmpfile: tempfile::NamedTempFile = match tempfile::NamedTempFile::new() {
+            Ok(f) => f,
+            Err(err) => {
+                return Err(format!("Could not create temporary file: {}", err));
+            }
+        };
+        // Download file
+        if let Err(err) = self.filetransfer_recv_one(file, tmpfile.path(), file.name.clone()) {
+            return Err(format!("Could not open file {}: {}", file.name, err));
+        }
+        // Get current file modification time
+        let prev_mtime: SystemTime = match self.host.stat(tmpfile.path()) {
+            Ok(e) => e.get_last_change_time(),
+            Err(err) => {
+                return Err(format!(
+                    "Could not stat \"{}\": {}",
+                    tmpfile.path().display(),
+                    err
+                ))
+            }
+        };
+        // Edit file
+        if let Err(err) = self.edit_local_file(tmpfile.path()) {
+            return Err(err);
+        }
+        // Get local fs entry
+        let tmpfile_entry: FsEntry = match self.host.stat(tmpfile.path()) {
+            Ok(e) => e,
+            Err(err) => {
+                return Err(format!(
+                    "Could not stat \"{}\": {}",
+                    tmpfile.path().display(),
+                    err
+                ))
+            }
+        };
+        // Check if file has changed
+        match prev_mtime != tmpfile_entry.get_last_change_time() {
+            true => {
+                self.log(
+                    LogLevel::Info,
+                    format!(
+                        "File \"{}\" has changed; writing changes to remote",
+                        file.abs_path.display()
+                    ),
+                );
+                // Get local fs entry
+                let tmpfile_entry: FsEntry = match self.host.stat(tmpfile.path()) {
+                    Ok(e) => e,
+                    Err(err) => {
+                        return Err(format!(
+                            "Could not stat \"{}\": {}",
+                            tmpfile.path().display(),
+                            err
+                        ))
+                    }
+                };
+                // Write file
+                let tmpfile_entry: &FsFile = match &tmpfile_entry {
+                    FsEntry::Directory(_) => panic!("tempfile is a directory for some reason"),
+                    FsEntry::File(f) => f,
+                };
+                // Send file
+                let wrkdir = self.remote().wrkdir.clone();
+                if let Err(err) = self.filetransfer_send_one(
+                    tmpfile_entry,
+                    wrkdir.as_path(),
+                    Some(file.name.clone()),
+                ) {
+                    return Err(format!(
+                        "Could not write file {}: {}",
+                        file.abs_path.display(),
+                        err
+                    ));
+                }
+            }
+            false => {
+                self.log(
+                    LogLevel::Info,
+                    format!("File \"{}\" hasn't changed", file.abs_path.display()),
+                );
+            }
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
# 37  - Fixed progress bar not visible when editing remote files

Fixes #37 

## Description

- New functions `send_one` and `recv_one` to transfer only one `FsFile` but mounting progress bar.
- Moved functions related to edit and tricky_copy from `session.rs` to action files.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit


## Tests

- [x] editing remote files still works
- [x] editing remote files now shows the progress bar
- [x] Non-regression on tricky-copy
