### PR TITLE
Ftp: cant move files to other directories

### DIFF
--- a/src/filetransfer/ftp_transfer.rs
+++ b/src/filetransfer/ftp_transfer.rs
@@ -723,17 +723,8 @@ impl FileTransfer for FtpFileTransfer {
                     FsEntry::Directory(dir) => dir.name.clone(),
                     FsEntry::File(file) => file.name.clone(),
                 };
-                let dst_name: PathBuf = match dst.file_name() {
-                    Some(p) => PathBuf::from(p),
-                    None => {
-                        return Err(FileTransferError::new_ex(
-                            FileTransferErrorType::FileCreateDenied,
-                            String::from("Invalid destination name"),
-                        ))
-                    }
-                };
                 // Only names are supported
-                match stream.rename(src_name.as_str(), &dst_name.as_path().to_string_lossy()) {
+                match stream.rename(src_name.as_str(), &dst.as_path().to_string_lossy()) {
                     Ok(_) => Ok(()),
                     Err(err) => Err(FileTransferError::new_ex(
                         FileTransferErrorType::FileCreateDenied,


### PR DESCRIPTION
# 44 - FTP: Can't move files to other directories

Fixes #44 

## Description

- Use destination path in `rename`

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit
