### PR TITLE
Fixed transfer size when sending multiple entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ Released on FIXME: ??
   - Fixed [Issue 44](https://github.com/veeso/termscp/issues/44): Could not move files to other paths in FTP
   - Fixed [Issue 43](https://github.com/veeso/termscp/issues/43): Could not remove non-empty directories in FTP
   - Fixed [Issue 39](https://github.com/veeso/termscp/issues/39): Help panels as `ScrollTable` to allow displaying entire content on small screens
+  - Fixed [Issue 38](https://github.com/veeso/termscp/issues/38): Transfer size was wrong when transferring "selected" files (with mark)
   - Fixed [Issue 37](https://github.com/veeso/termscp/issues/37): progress bar not visible when editing remote files
 - Dependencies:
   - Updated `textwrap` to `0.14.0`

--- a/src/fs/mod.rs
+++ b/src/fs/mod.rs
@@ -227,7 +227,6 @@ impl FsEntry {
         }
     }
 
-    #[cfg(test)]
     /// ### unwrap_file
     ///
     /// Unwrap FsEntry as FsFile

--- a/src/ui/activities/filetransfer/actions/mod.rs
+++ b/src/ui/activities/filetransfer/actions/mod.rs
@@ -78,8 +78,7 @@ impl FileTransferActivity {
                 let files: Vec<&FsEntry> = files
                     .iter()
                     .map(|x| self.local().get(*x)) // Usize to Option<FsEntry>
-                    .filter(|x| x.is_some()) // Get only some values
-                    .map(|x| x.unwrap()) // Option to FsEntry
+                    .flatten()
                     .collect();
                 SelectedEntry::from(files)
             }
@@ -97,8 +96,7 @@ impl FileTransferActivity {
                 let files: Vec<&FsEntry> = files
                     .iter()
                     .map(|x| self.remote().get(*x)) // Usize to Option<FsEntry>
-                    .filter(|x| x.is_some()) // Get only some values
-                    .map(|x| x.unwrap()) // Option to FsEntry
+                    .flatten()
                     .collect();
                 SelectedEntry::from(files)
             }
@@ -118,8 +116,7 @@ impl FileTransferActivity {
                 let files: Vec<&FsEntry> = files
                     .iter()
                     .map(|x| self.found().as_ref().unwrap().get(*x)) // Usize to Option<FsEntry>
-                    .filter(|x| x.is_some()) // Get only some values
-                    .map(|x| x.unwrap()) // Option to FsEntry
+                    .flatten()
                     .collect();
                 SelectedEntry::from(files)
             }

--- a/src/ui/activities/filetransfer/actions/mod.rs
+++ b/src/ui/activities/filetransfer/actions/mod.rs
@@ -25,7 +25,7 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-pub(self) use super::{FileTransferActivity, FsEntry, LogLevel};
+pub(self) use super::{FileTransferActivity, FsEntry, LogLevel, TransferPayload};
 use tuirealm::{Payload, Value};
 
 // actions

--- a/src/ui/activities/filetransfer/mod.rs
+++ b/src/ui/activities/filetransfer/mod.rs
@@ -49,9 +49,10 @@ use crate::fs::explorer::FileExplorer;
 use crate::fs::FsEntry;
 use crate::host::Localhost;
 use crate::system::config_client::ConfigClient;
-pub(crate) use lib::browser;
+pub(self) use lib::browser;
 use lib::browser::Browser;
 use lib::transfer::TransferStates;
+pub(self) use session::TransferPayload;
 
 // Includes
 use chrono::{DateTime, Local};

--- a/src/ui/activities/filetransfer/session.rs
+++ b/src/ui/activities/filetransfer/session.rs
@@ -252,18 +252,17 @@ impl FileTransferActivity {
         // Reset states
         self.transfer.reset();
         // Calculate total size of transfer
-        let mut total_transfer_size: usize = 0;
-        for entry in entries.iter() {
-            total_transfer_size += self.get_total_transfer_size_local(entry);
-        }
+        let total_transfer_size: usize = entries
+            .iter()
+            .map(|x| self.get_total_transfer_size_local(x))
+            .sum();
         self.transfer.full.init(total_transfer_size);
         // Mount progress bar
         self.mount_progress_bar(format!("Uploading {} entries...", entries.len()));
         // Send recurse
-        for entry in entries.iter() {
-            // Send
-            self.filetransfer_send_recurse(entry, curr_remote_path, None);
-        }
+        entries
+            .iter()
+            .for_each(|x| self.filetransfer_send_recurse(x, curr_remote_path, None));
         // Umount progress bar
         self.umount_progress_bar();
         Ok(())
@@ -569,18 +568,17 @@ impl FileTransferActivity {
         // Reset states
         self.transfer.reset();
         // Calculate total size of transfer
-        let mut total_transfer_size: usize = 0;
-        for entry in entries.iter() {
-            total_transfer_size += self.get_total_transfer_size_remote(entry);
-        }
+        let total_transfer_size: usize = entries
+            .iter()
+            .map(|x| self.get_total_transfer_size_remote(x))
+            .sum();
         self.transfer.full.init(total_transfer_size);
         // Mount progress bar
-        self.mount_progress_bar(format!("Uploading {} entries...", entries.len()));
+        self.mount_progress_bar(format!("Downloading {} entries...", entries.len()));
         // Send recurse
-        for entry in entries.iter() {
-            // Send
-            self.filetransfer_recv_recurse(entry, curr_remote_path, None);
-        }
+        entries
+            .iter()
+            .for_each(|x| self.filetransfer_recv_recurse(x, curr_remote_path, None));
         // Umount progress bar
         self.umount_progress_bar();
         Ok(())


### PR DESCRIPTION
# 38 - Fixed transfer size when sending multiple entries

Fixes #38 

## Description

- TransferPayload entity to describe the payload of a transfer in session.rs
- Single function to send and receive file entries
- Calculate transfer size based on entity

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

- [x] regression test: send entry
- [x] regression test: send many
- [x] regression test: edit remote file
- [x] regression test: recv entry
- [x] regression test: recv many
- [x] regression test: tricky copy
- [x] regression test: send found entry
- [x] regression test: send found many
- [x] regression test: recv found entry
- [x] regression test: recv found many


