### PR TITLE
Fix: When copying files with tricky copy, the upper progress bar shows no text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ Released on ??
   - Added new `Directory already exists` variant for file transfer errors
 - Bugfix:
   - Fixed [Issue 58](https://github.com/veeso/termscp/issues/58):When uploading a directory, create directory only if it doesn't exist
+  - Fixed [Issue 59](https://github.com/veeso/termscp/issues/59): When copying files with tricky copy, the upper progress bar shows no text
 - Dependencies:
   - Updated `bitflags` to `1.3.2`
   - Updated `bytesize` to `1.1.0`

--- a/src/ui/activities/filetransfer/actions/copy.rs
+++ b/src/ui/activities/filetransfer/actions/copy.rs
@@ -144,6 +144,8 @@ impl FileTransferActivity {
     ///
     /// Tricky copy will be used whenever copy command is not available on remote host
     fn tricky_copy(&mut self, entry: FsEntry, dest: &Path) {
+        // NOTE: VERY IMPORTANT; wait block must be umounted or something really bad will happen
+        self.umount_wait();
         // match entry
         match entry {
             FsEntry::File(entry) => {


### PR DESCRIPTION
# 58 - Fixed When copying files with tricky copy, the upper progress bar shows no text

Fixes #58 

## Description

- Umount wait popup before performing tricky copy. The wait popup caused the ui to break when using tricky copy.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

- [x] regression test: tricky copy
