### PR TITLE
Using termscp as a dependency fails to compile #74

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@
 
 ---
 
+## Unreleased
+
+- Bugfix:
+  - Fixed [Issue 74](https://github.com/veeso/termscp/issues/74): Minor update to tui-realm-stdlib dependency breaks compatibility
+- Dependencies:
+  - Updated `tui-realm-stdlib` to `0.6.3`
+
 ## 0.6.1
 
 Released on 31/08/2021
@@ -28,7 +35,7 @@ Released on 31/08/2021
   - Now that tui-rs supports title alignment, UI has been improved
   - Added new `Directory already exists` variant for file transfer errors
 - Bugfix:
-  - Fixed [Issue 58](https://github.com/veeso/termscp/issues/58):When uploading a directory, create directory only if it doesn't exist
+  - Fixed [Issue 58](https://github.com/veeso/termscp/issues/58): When uploading a directory, create directory only if it doesn't exist
   - Fixed [Issue 59](https://github.com/veeso/termscp/issues/59): When copying files with tricky copy, the upper progress bar shows no text
 - Dependencies:
   - Updated `bitflags` to `1.3.2`
@@ -135,10 +142,10 @@ Released on 23/05/2021
   - termscp now writes a log file, useful to debug and to contribute to fix issues.
   - Read more on [manual](docs/man.md)
 - **File transfer changes**
-  - *SFTP*
+  - _SFTP_
     - Added **COPY** command to SFTP (Please note that Copy command is not supported by SFTP natively, so here it just uses the `cp` shell command as it does in SCP).
-  - *FTP*
-    - Added support for file copy (achieved through *tricky-copy*: the file is first downloaded, then uploaded with a different file name)
+  - _FTP_
+    - Added support for file copy (achieved through _tricky-copy_: the file is first downloaded, then uploaded with a different file name)
 - **Double progress bar**:
   - From now one two progress bar will be displayed:
     - the first, on top, displays the full transfer state (e.g. when downloading a directory of 10 files, the progress of the entire transfer)
@@ -276,7 +283,7 @@ Released on 18/01/2021
 
 ## 0.3.0
 
- Released on 10/01/2021
+Released on 10/01/2021
 
 > The SSH Key Storage Update
 
@@ -345,7 +352,7 @@ Released on 21/12/2020
   - `O`: Open text file in editor
 - Enhancements:
   - User interface
-    - Collpased borders to make everything more *aesthetic*
+    - Collpased borders to make everything more _aesthetic_
     - Rounded input field boards
     - File explorer:
       - Log how long it took to upload/download a file and the transfer speed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1500,9 +1500,9 @@ dependencies = [
 
 [[package]]
 name = "tui-realm-stdlib"
-version = "0.6.0"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bff91e1cdc741a7487d8cb20ac038e5ba926a0ec97b0f2ea918ac75640b9da5"
+checksum = "f159d383b40dec75e0541530bc3416318f5e0a8b6999db9df9b5efa6b122380e"
 dependencies = [
  "textwrap",
  "tuirealm",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,7 +52,7 @@ tempfile = "3.1.0"
 textwrap = "0.14.2"
 thiserror = "^1.0.0"
 toml = "0.5.8"
-tui-realm-stdlib = "0.6.0"
+tui-realm-stdlib = "0.6.3"
 tuirealm = "0.6.0"
 ureq = { version = "2.1.0", features = [ "json" ] }
 whoami = "1.1.1"

--- a/src/ui/activities/auth/bookmarks.rs
+++ b/src/ui/activities/auth/bookmarks.rs
@@ -32,7 +32,7 @@ use crate::system::environment;
 
 // Ext
 use std::path::PathBuf;
-use tui_realm_stdlib::{input::InputPropsBuilder, radio::RadioPropsBuilder};
+use tui_realm_stdlib::{InputPropsBuilder, RadioPropsBuilder};
 use tuirealm::{Payload, PropsBuilder, Value};
 
 impl AuthActivity {

--- a/src/ui/activities/auth/view.rs
+++ b/src/ui/activities/auth/view.rs
@@ -31,13 +31,9 @@ use crate::ui::components::bookmark_list::{BookmarkList, BookmarkListPropsBuilde
 use crate::utils::ui::draw_area_in;
 // Ext
 use tui_realm_stdlib::{
-    input::{Input, InputPropsBuilder},
-    label::{Label, LabelPropsBuilder},
-    list::{List, ListPropsBuilder},
-    paragraph::{Paragraph, ParagraphPropsBuilder},
-    radio::{Radio, RadioPropsBuilder},
-    span::{Span, SpanPropsBuilder},
-    textarea::{Textarea, TextareaPropsBuilder},
+    {Input, InputPropsBuilder}, {Label, LabelPropsBuilder}, {List, ListPropsBuilder},
+    {Paragraph, ParagraphPropsBuilder}, {Radio, RadioPropsBuilder}, {Span, SpanPropsBuilder},
+    {Textarea, TextareaPropsBuilder},
 };
 use tuirealm::tui::{
     layout::{Constraint, Direction, Layout},

--- a/src/ui/activities/filetransfer/update.rs
+++ b/src/ui/activities/filetransfer/update.rs
@@ -42,7 +42,7 @@ use crate::ui::components::{file_list::FileListPropsBuilder, logbox::LogboxProps
 use crate::ui::keymap::*;
 use crate::utils::fmt::fmt_path_elide_ex;
 // externals
-use tui_realm_stdlib::progress_bar::ProgressBarPropsBuilder;
+use tui_realm_stdlib::ProgressBarPropsBuilder;
 use tuirealm::{
     props::{Alignment, PropsBuilder, TableBuilder, TextSpan},
     tui::style::Color,

--- a/src/ui/activities/filetransfer/view.rs
+++ b/src/ui/activities/filetransfer/view.rs
@@ -40,13 +40,9 @@ use crate::utils::ui::draw_area_in;
 use bytesize::ByteSize;
 use std::path::PathBuf;
 use tui_realm_stdlib::{
-    input::{Input, InputPropsBuilder},
-    list::{List, ListPropsBuilder},
-    paragraph::{Paragraph, ParagraphPropsBuilder},
-    progress_bar::{ProgressBar, ProgressBarPropsBuilder},
-    radio::{Radio, RadioPropsBuilder},
-    span::{Span, SpanPropsBuilder},
-    table::{Table, TablePropsBuilder},
+    {Input, InputPropsBuilder}, {List, ListPropsBuilder}, {Paragraph, ParagraphPropsBuilder},
+    {ProgressBar, ProgressBarPropsBuilder}, {Radio, RadioPropsBuilder}, {Span, SpanPropsBuilder},
+    {Table, TablePropsBuilder},
 };
 use tuirealm::props::{Alignment, PropsBuilder, TableBuilder, TextSpan};
 use tuirealm::tui::{

--- a/src/ui/activities/setup/view/mod.rs
+++ b/src/ui/activities/setup/view/mod.rs
@@ -36,10 +36,8 @@ pub use ssh_keys::*;
 pub use theme::*;
 // Ext
 use tui_realm_stdlib::{
-    list::{List, ListPropsBuilder},
-    paragraph::{Paragraph, ParagraphPropsBuilder},
-    radio::{Radio, RadioPropsBuilder},
-    span::{Span, SpanPropsBuilder},
+    {List, ListPropsBuilder}, {Paragraph, ParagraphPropsBuilder}, {Radio, RadioPropsBuilder},
+    {Span, SpanPropsBuilder},
 };
 use tuirealm::props::{Alignment, PropsBuilder, TableBuilder, TextSpan};
 use tuirealm::tui::{

--- a/src/ui/activities/setup/view/setup.rs
+++ b/src/ui/activities/setup/view/setup.rs
@@ -34,8 +34,7 @@ use crate::utils::ui::draw_area_in;
 // Ext
 use std::path::PathBuf;
 use tui_realm_stdlib::{
-    input::{Input, InputPropsBuilder},
-    radio::{Radio, RadioPropsBuilder},
+    {Input, InputPropsBuilder}, {Radio, RadioPropsBuilder},
 };
 use tuirealm::tui::{
     layout::{Constraint, Direction, Layout},

--- a/src/ui/activities/setup/view/ssh_keys.rs
+++ b/src/ui/activities/setup/view/ssh_keys.rs
@@ -32,8 +32,7 @@ use crate::ui::components::bookmark_list::{BookmarkList, BookmarkListPropsBuilde
 use crate::utils::ui::draw_area_in;
 // Ext
 use tui_realm_stdlib::{
-    input::{Input, InputPropsBuilder},
-    radio::{Radio, RadioPropsBuilder},
+    {Input, InputPropsBuilder}, {Radio, RadioPropsBuilder},
 };
 use tuirealm::tui::{
     layout::{Constraint, Direction, Layout},

--- a/src/ui/activities/setup/view/theme.rs
+++ b/src/ui/activities/setup/view/theme.rs
@@ -33,7 +33,7 @@ use crate::ui::components::color_picker::{ColorPicker, ColorPickerPropsBuilder};
 use crate::utils::parser::parse_color;
 use crate::utils::ui::draw_area_in;
 // Ext
-use tui_realm_stdlib::label::{Label, LabelPropsBuilder};
+use tui_realm_stdlib::{Label, LabelPropsBuilder};
 use tuirealm::tui::{
     layout::{Constraint, Direction, Layout},
     style::Color,

--- a/src/ui/components/color_picker.rs
+++ b/src/ui/components/color_picker.rs
@@ -30,7 +30,7 @@
 use crate::utils::fmt::fmt_color;
 use crate::utils::parser::parse_color;
 // ext
-use tui_realm_stdlib::input::{Input, InputPropsBuilder};
+use tui_realm_stdlib::{Input, InputPropsBuilder};
 use tuirealm::event::Event;
 use tuirealm::props::{Alignment, Props, PropsBuilder};
 use tuirealm::tui::{


### PR DESCRIPTION
This pr updates tui-realm-stdlib to its latest version, 0.6.3, and fixes the incompatibility from tui-realm-stdlib 0.6.0.

I'm not sure if you want to yank the latest version tui-realm-stdlib that has this change, but for now this pr will fix any issues it has caused.