### PR TITLE
Fix shortcut description in footer

### DIFF
--- a/src/ui/activities/filetransfer/components/misc.rs
+++ b/src/ui/activities/filetransfer/components/misc.rs
@@ -61,7 +61,7 @@ impl FooterBar {
                 TextSpan::from("<F7|D>").bold().fg(key_color),
                 TextSpan::from(" Make dir "),
                 TextSpan::from("<F8|DEL>").bold().fg(key_color),
-                TextSpan::from(" Make dir "),
+                TextSpan::from(" Delete "),
                 TextSpan::from("<F10|Q>").bold().fg(key_color),
                 TextSpan::from(" Quit "),
             ]),


### PR DESCRIPTION
# Fix shortcut description in footer

## Description

The 'Delete' shortcut was listed as 'Make dir', probably a copy paste oversight from the previous item.

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
