### PR TITLE
macos arm64 build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ dist/pkgs/arch/*.tar.gz
 .DS_Store
 
 dist/pkgs/
+dist/build/macos/openssl/

--- a/dist/build/macos.sh
+++ b/dist/build/macos.sh
@@ -1,11 +1,64 @@
 #!/bin/sh
 
+make_pkg() {
+    ARCH=$1
+    VERSION=$2
+    TARGET_DIR="$3"
+    if [ -z "$TARGET_DIR" ]; then
+        TARGET_DIR=target/release/
+    fi
+    cd $TARGET_DIR
+    PKG="termscp-v${VERSION}-${ARCH}-apple-darwin.tar.gz"
+    tar czf $PKG termscp
+    HASH=$(sha256sum $PKG)
+    mkdir -p ../../dist/pkgs/macos/
+    mv $PKG ../../dist/pkgs/macos/$PKG
+    cd -
+    echo "$HASH"
+}
+
+build_openssl_arm64() {
+    # setup dirs
+    BUILD_DIR=$(pwd)
+    OPENSSL_BUILD_DIR=/tmp/openssl-build/
+    # setup openssl dir
+    mkdir -p $OPENSSL_DIR
+    cd $OPENSSL_DIR
+    # check if openssl has already been compiled
+    if [ -e ./include/ ]; then
+        return 0
+    fi
+    # download package
+    TEMP_TGZ=/tmp/openssl.tar.gz
+    wget https://www.openssl.org/source/openssl-1.1.1m.tar.gz -O $TEMP_TGZ
+    # setup build dir
+    mkdir -p $OPENSSL_BUILD_DIR
+    cd $OPENSSL_BUILD_DIR
+    # extract sources
+    tar xzvf $TEMP_TGZ
+    rm $TEMP_TGZ
+    # build
+    cd openssl-1.1.1m/
+    export MACOSX_DEPLOYMENT_TARGET=10.15
+    ./Configure enable-rc5 zlib darwin64-arm64-cc no-asm
+    make
+    make install DESTDIR=$(pwd)/out/
+    # copy compiled assets to openssl dir
+    cp -r out/usr/local/* $OPENSSL_DIR/
+    # go back to build dir
+    cd $BUILD_DIR
+    # delete temp dir
+    rm -rf $OPENSSL_BUILD_DIR
+    return 0
+}
+
 if [ -z "$1" ]; then
     echo "Usage: macos.sh <version>"
     exit 1
 fi
 
 VERSION=$1
+export BUILD_ROOT=$(pwd)/../../
 
 set -e # Don't fail
 
@@ -17,14 +70,25 @@ if [ ! -f Cargo.toml ]; then
     exit 1
 fi
 
-# Build release
+# Build release (x86_64)
 cargo build --release
 # Make pkg
-cd target/release/
-PKG="termscp-v${VERSION}-x86_64-apple-darwin.tar.gz"
-tar czf $PKG termscp
-sha256sum $PKG
-mkdir -p ../../dist/pkgs/macos/
-mv $PKG ../../dist/pkgs/macos/$PKG
+X86_64_HASH=$(make_pkg "x86_64" $VERSION)
+
+# set openssl dir
+export OPENSSL_DIR=$BUILD_ROOT/dist/build/macos/openssl/
+export OPENSSL_STATIC=1
+export OPENSSL_LIB_DIR=${OPENSSL_DIR}/lib/
+export OPENSSL_INCLUDE_DIR=${OPENSSL_DIR}/include/
+# build openssl
+build_openssl_arm64
+cd $BUILD_ROOT
+# Build ARM64 pkg
+cargo build --release --target aarch64-apple-darwin
+# Make pkg
+ARM64_HASH=$(make_pkg "arm64" $VERSION "target/aarch64-apple-darwin/release/")
+
+echo "x86_64 hash: $X86_64_HASH"
+echo "arm64  hash: $ARM64_HASH"
 
 exit $?

--- a/install.sh
+++ b/install.sh
@@ -266,13 +266,19 @@ install_on_linux() {
 
 install_on_macos() {
     if has brew; then
+        # get homebrew formula name
+        if [ "${ARCH}" != "x86_64" ]; then
+            FORMULA="termscp"
+        else
+            FORMULA="termscp-m1"
+        fi
         if has termscp; then
             info "Upgrading ${GREEN}termscp${NO_COLOR}…"
             # The OR is used since someone could have installed via cargo previously
-            brew update && brew upgrade termscp || brew install veeso/termscp/termscp
+            brew update && brew upgrade ${FORMULA} || brew install veeso/termscp/${FORMULA}
         else
             info "Installing ${GREEN}termscp${NO_COLOR}…"
-            brew install veeso/termscp/termscp
+            brew install veeso/termscp/${FORMULA}
         fi
     else
         try_with_cargo "brew is missing on your system; please install it from <https://brew.sh/>"


### PR DESCRIPTION
# Issue 95 - Support Mac M1 chip

Fixes #95 

## Description

- Added to macos.sh build script the build for Apple M1 chip.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

- [x] the binary produced by the script can run on a M1 Mac
