### PR TITLE
Fixed termscp panics when displaying long non-ascii filenames

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ Released on ??
 
 - **Enhancements**
   - Write exitcode to log when termscp terminates
+- Bugfix:
+  - [Issue 104](https://github.com/veeso/termscp/issues/104): Fixed termscp panics when displaying long non-ascii filenames
 
 ## 0.8.1
 

--- a/src/utils/fmt.rs
+++ b/src/utils/fmt.rs
@@ -31,6 +31,7 @@ use chrono::prelude::*;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime};
 use tuirealm::tui::style::Color;
+use unicode_width::UnicodeWidthStr;
 
 /// ### fmt_pex
 ///
@@ -85,7 +86,7 @@ pub fn fmt_path_elide(p: &Path, width: usize) -> String {
 /// This function allows to specify an extra length to consider to elide path
 pub fn fmt_path_elide_ex(p: &Path, width: usize, extra_len: usize) -> String {
     let fmt_path: String = format!("{}", p.display());
-    match fmt_path.len() + extra_len > width as usize {
+    match fmt_path.width() + extra_len > width as usize {
         false => fmt_path,
         true => {
             // Elide

--- a/src/utils/string.rs
+++ b/src/utils/string.rs
@@ -1,11 +1,11 @@
-//! ## Utils
+//! # String
 //!
-//! `utils` is the module which provides utilities of different kind
+//! String related utilities
 
 /**
  * MIT License
  *
- * termscp - Copyright (c) 2021 Christian Visintin
+ * termscp - Copyright (c) 2022 Christian Visintin
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -25,16 +25,21 @@
  * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
  * SOFTWARE.
  */
-// modules
-pub mod crypto;
-pub mod file;
-pub mod fmt;
-pub mod parser;
-pub mod path;
-pub mod random;
-pub mod string;
-pub mod ui;
+
+/// Get a substring considering utf8 characters
+pub fn secure_substring(string: &str, start: usize, end: usize) -> String {
+    assert!(end >= start);
+    string.chars().take(end).skip(start).collect()
+}
 
 #[cfg(test)]
-#[allow(dead_code)]
-pub mod test_helpers;
+mod test {
+
+    use super::*;
+
+    #[test]
+    fn should_get_secure_substring() {
+        assert_eq!(secure_substring("christian", 2, 5).as_str(), "ris");
+        assert_eq!(secure_substring("россия", 3, 5).as_str(), "си");
+    }
+}


### PR DESCRIPTION
# 104 - Fixed termscp panics when displaying long non-ascii filenames

Fixes #104 

## Description

- Use unicode width to get string length in fmt_name and fmt_path
- safe substring function to get filenames

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

- [x] regression test: should format file names correctly
- [x] non ascii filenames should not make termscp to crash when displayed
