### PR TITLE
fix typo

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -264,7 +264,7 @@ install_on_macos() {
         # get homebrew formula name
         if [ "${ARCH}" == "x86_64" ]; then
             FORMULA="termscp"
-        elif [ "$ARCH" == "aarch64" ] then
+        elif [ "$ARCH" == "aarch64" ]; then
             FORMULA="termscp-m1"
         else
             error "unsupported arch: $ARCH"


### PR DESCRIPTION
# Fix `install.sh` file

`./install.sh: line 269: syntax error near unexpected token 'else' `

## Description

- I changed `install.sh` file typo for `aarch64` support


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
