### PR TITLE
126 new feature termscp doesnt use id rsa default ssh private key to authenticate to sftp scp endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Released on ??
 - **Bugfix**:
   - Fixed [Issue 141](https://github.com/veeso/termcp/issues/141)
 - Dependencies:
+  - Bump `remotefs-ssh` to `0.1.3`
   - Bump `ssh2-config` to `0.1.4`
 
 ## 0.10.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [0.11.0](#0110)
   - [0.10.0](#0100)
   - [0.9.0](#090)
   - [0.8.2](#082)
@@ -25,6 +26,17 @@
   - [0.1.0](#010)
 
 ---
+
+## 0.11.0
+
+Released on ??
+
+> 🦥 The lazy update
+
+- **Bugfix**:
+  - Fixed [Issue 141](https://github.com/veeso/termcp/issues/141)
+- Dependencies:
+  - Bump `ssh2-config` to `0.1.4`
 
 ## 0.10.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,8 @@ Released on ??
 > 🦥 The lazy update
 
 - **Bugfix**:
-  - Fixed [Issue 141](https://github.com/veeso/termcp/issues/141)
+  - Fixed [Issue 126](https://github.com/veeso/termscp/issues/126)
+  - Fixed [Issue 141](https://github.com/veeso/termscp/issues/141)
 - Dependencies:
   - Bump `remotefs-ssh` to `0.1.3`
   - Bump `ssh2-config` to `0.1.4`

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2548,9 +2548,9 @@ dependencies = [
 
 [[package]]
 name = "ssh2-config"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23ab9de63060578308d874ed89c9e362884506cb7f7f9e350af4dd3679ac321a"
+checksum = "36ab5061c49144b158574b19c0e19d21ae97bed7f7bcf438dfe21fa27a46b633"
 dependencies = [
  "dirs",
  "thiserror",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2070,9 +2070,9 @@ dependencies = [
 
 [[package]]
 name = "remotefs-ssh"
-version = "0.1.2"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "190106b53b839cf094172d2f1bc14e8d2846a69de06b239f11c2fc353080e9e0"
+checksum = "8bcccc51bbdd0d32e1d3ab7076edd03943a195a267809cbceba6ec40e9d54f93"
 dependencies = [
  "chrono",
  "lazy_static",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,12 +77,12 @@ with-keyring = [ "keyring" ]
 [target."cfg(target_family = \"windows\")"]
 [target."cfg(target_family = \"windows\")".dependencies]
 remotefs-ftp = { version = "^0.1.2", features = [ "native-tls" ] }
-remotefs-ssh = "^0.1.2"
+remotefs-ssh = "^0.1.3"
 
 [target."cfg(target_family = \"unix\")"]
 [target."cfg(target_family = \"unix\")".dependencies]
 remotefs-ftp = { version = "^0.1.2", features = [ "vendored", "native-tls" ] }
-remotefs-ssh = { version = "^0.1.2", features = [ "ssh2-vendored" ] }
+remotefs-ssh = { version = "^0.1.3", features = [ "ssh2-vendored" ] }
 users = "0.11.0"
 
 [profile.dev]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,7 +54,7 @@ rpassword = "^7.0"
 self_update = { version = "^0.32", default-features = false, features = [ "rustls", "archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate" ] }
 serde = { version = "^1", features = [ "derive" ] }
 simplelog = "^0.12"
-ssh2-config = "^0.1.3"
+ssh2-config = "^0.1.4"
 tempfile = "^3.2"
 thiserror = "^1"
 toml = "^0.5"

--- a/src/config/serialization.rs
+++ b/src/config/serialization.rs
@@ -119,7 +119,7 @@ mod tests {
 
     use pretty_assertions::assert_eq;
     use std::collections::HashMap;
-    use std::io::{Seek, SeekFrom};
+    use std::io::Seek;
     use std::path::PathBuf;
     use tuirealm::tui::style::Color;
 

--- a/src/system/sshkey_storage.rs
+++ b/src/system/sshkey_storage.rs
@@ -10,6 +10,7 @@ use ssh2_config::SshConfig;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
+#[derive(Default)]
 pub struct SshKeyStorage {
     /// Association between {user}@{host} and RSA key path
     hosts: HashMap<String, PathBuf>,
@@ -18,15 +19,6 @@ pub struct SshKeyStorage {
 }
 
 impl SshKeyStorage {
-    /// Create an empty ssh key storage; used in case `ConfigClient` is not available
-    #[cfg(test)]
-    pub fn empty() -> Self {
-        SshKeyStorage {
-            hosts: HashMap::new(),
-            ssh_config: None,
-        }
-    }
-
     /// Make mapkey from host and username
     fn make_mapkey(host: &str, username: &str) -> String {
         format!("{username}@{host}")
@@ -61,16 +53,18 @@ impl SshKeyStorage {
 
     /// Resolve host via ssh2 configuration
     fn resolve_host_in_ssh2_configuration(&self, host: &str) -> Option<PathBuf> {
-        if let Some(config) = self.ssh_config.as_ref() {
-            let params = config.query(host);
-            params
-                .identity_file
-                .as_ref()
-                .and_then(|x| x.get(0).cloned())
-        } else {
-            debug!("ssh2 config is not available; no key has been found");
-            None
-        }
+        self.ssh_config
+            .as_ref()
+            .map(|x| {
+                let key = x
+                    .query(host)
+                    .identity_file
+                    .as_ref()
+                    .and_then(|x| x.get(0).cloned());
+
+                key
+            })
+            .flatten()
     }
 }
 
@@ -85,7 +79,9 @@ impl SshKeyStorageTrait for SshKeyStorage {
             username, host
         );
         // otherwise search in configuration
-        self.resolve_host_in_ssh2_configuration(host)
+        let key = self.resolve_host_in_ssh2_configuration(host)?;
+        debug!("Found key in SSH config for {host}: {}", key.display());
+        Some(key)
     }
 }
 
@@ -186,13 +182,13 @@ Host test
 
     #[test]
     fn test_system_sshkey_storage_empty() {
-        let storage: SshKeyStorage = SshKeyStorage::empty();
+        let storage: SshKeyStorage = SshKeyStorage::default();
         assert_eq!(storage.hosts.len(), 0);
     }
 
     #[test]
     fn test_system_sshkey_storage_add() {
-        let mut storage: SshKeyStorage = SshKeyStorage::empty();
+        let mut storage: SshKeyStorage = SshKeyStorage::default();
         storage.add_key("deskichup", "veeso", PathBuf::from("/tmp/omar"));
         assert_eq!(
             *storage.resolve("deskichup", "veeso").unwrap(),

--- a/src/system/sshkey_storage.rs
+++ b/src/system/sshkey_storage.rs
@@ -55,7 +55,7 @@ impl SshKeyStorage {
     fn resolve_host_in_ssh2_configuration(&self, host: &str) -> Option<PathBuf> {
         self.ssh_config
             .as_ref()
-            .map(|x| {
+            .and_then(|x| {
                 let key = x
                     .query(host)
                     .identity_file
@@ -64,7 +64,6 @@ impl SshKeyStorage {
 
                 key
             })
-            .flatten()
     }
 }
 

--- a/src/system/sshkey_storage.rs
+++ b/src/system/sshkey_storage.rs
@@ -53,17 +53,15 @@ impl SshKeyStorage {
 
     /// Resolve host via ssh2 configuration
     fn resolve_host_in_ssh2_configuration(&self, host: &str) -> Option<PathBuf> {
-        self.ssh_config
-            .as_ref()
-            .and_then(|x| {
-                let key = x
-                    .query(host)
-                    .identity_file
-                    .as_ref()
-                    .and_then(|x| x.get(0).cloned());
+        self.ssh_config.as_ref().and_then(|x| {
+            let key = x
+                .query(host)
+                .identity_file
+                .as_ref()
+                .and_then(|x| x.get(0).cloned());
 
-                key
-            })
+            key
+        })
     }
 }
 


### PR DESCRIPTION
# ISSUE 126 - termscp doesn't use IdentityFile on ssh authentication

Fixes #126 

## Description

- Bump remotefs-ssh 0.1.3
- Optimized ssh key storage

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

- [x] regression test: ssh authentication
- [x] I can login with IdentityFile ssh
