### PR TITLE
SSH configuration path is not `~/.ssh/config` by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@ Released on ??
 
 > 🦥 The lazy update
 
+- **Default ssh config path**:
+  - SSH configuration path is not `~/.ssh/config` by default
 - **Bugfix**:
   - Fixed [Issue 126](https://github.com/veeso/termscp/issues/126)
   - Fixed [Issue 141](https://github.com/veeso/termscp/issues/141)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ Released on ??
 > 🦥 The lazy update
 
 - **Default ssh config path**:
-  - SSH configuration path is not `~/.ssh/config` by default
+  - SSH configuration path is now `~/.ssh/config` by default
 - **Bugfix**:
   - Fixed [Issue 126](https://github.com/veeso/termscp/issues/126)
   - Fixed [Issue 141](https://github.com/veeso/termscp/issues/141)

--- a/src/config/params.rs
+++ b/src/config/params.rs
@@ -36,7 +36,7 @@ pub struct UserInterfaceConfig {
     pub notification_threshold: Option<u64>, // @! Since 0.7.0; Default 512MB
 }
 
-#[derive(Deserialize, Serialize, Debug, Default)]
+#[derive(Deserialize, Serialize, Debug)]
 /// Contains configuratio related to remote hosts
 pub struct RemoteConfig {
     /// Ssh configuration path. If NONE, won't be read
@@ -44,6 +44,19 @@ pub struct RemoteConfig {
     /// Association between host name and path to private key
     /// NOTE: this parameter must stay as last: <https://github.com/alexcrichton/toml-rs/issues/142>
     pub ssh_keys: HashMap<String, PathBuf>,
+}
+
+impl Default for RemoteConfig {
+    fn default() -> Self {
+        let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/root"));
+        let mut ssh_config_path = "~/.ssh/config".to_string();
+        ssh_config_path = ssh_config_path.replacen('~', &home_dir.to_string_lossy(), 1);
+
+        Self {
+            ssh_config: Some(ssh_config_path),
+            ssh_keys: HashMap::default(),
+        }
+    }
 }
 
 impl Default for UserInterfaceConfig {

--- a/src/system/config_client.rs
+++ b/src/system/config_client.rs
@@ -651,7 +651,11 @@ mod tests {
         let mut client: ConfigClient = ConfigClient::new(cfg_path.as_path(), key_path.as_path())
             .ok()
             .unwrap();
-        assert_eq!(client.get_ssh_config(), None); // Null ?
+
+        let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/root"));
+        let mut ssh_config_path = "~/.ssh/config".to_string();
+        ssh_config_path = ssh_config_path.replacen('~', &home_dir.to_string_lossy(), 1);
+        assert_eq!(client.get_ssh_config(), Some(ssh_config_path.as_str())); // Null ?
         client.set_ssh_config(Some(String::from("/tmp/ssh_config")));
         assert_eq!(client.get_ssh_config(), Some("/tmp/ssh_config"));
         client.set_ssh_config(None);


### PR DESCRIPTION
# ISSUE 130 - SSH configuration path is not `~/.ssh/config` by default

Fixes #130 

## Description

- SSH configuration path is now `~/.ssh/config` by default

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

