### PR TITLE
Optimize transfers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Released on 14/02/2023
 
 > 🦥 The lazy update
 
+- **Transfers optimized**:
+  - If local/remote file have the same "last modification time" (`mtime`), the file is not transferred
+  - When the file is exchanged, all times attributes are set (if supported by the protocol)
 - **Default ssh config path**:
   - SSH configuration path is now `~/.ssh/config` by default
 - Added ARM64 Linux builds

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2670,6 +2670,7 @@ dependencies = [
  "content_inspector",
  "dirs",
  "edit",
+ "filetime",
  "hostname",
  "keyring",
  "lazy-regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ chrono = "^0.4"
 content_inspector = "^0.2"
 dirs = "^4.0"
 edit = "^0.1"
+filetime = "^0.2"
 hostname = "^0.3"
 keyring = { version = "^1.2", optional = true }
 lazy-regex = "^2.4"


### PR DESCRIPTION
# ISSUE 133 - Transfer resuming

Fixes #133 

## Description

- **Transfers optimized**:
  - If local/remote file have the same "last modification time" (`mtime`), the file is not transferred
  - When the file is exchanged, all times attributes are set (if supported by the protocol)

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

