### PR TITLE
issue 150: some issues with configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [0.11.1](#0111)
   - [0.11.0](#0110)
   - [0.10.0](#0100)
   - [0.9.0](#090)
@@ -26,6 +27,12 @@
   - [0.1.0](#010)
 
 ---
+
+## 0.11.1
+
+Released on ??
+
+- [Issue 150](https://github.com/veeso/termscp/issues/150): fixed config directory not being created
 
 ## 0.11.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,7 +32,9 @@
 
 Released on ??
 
-- [Issue 150](https://github.com/veeso/termscp/issues/150): fixed config directory not being created
+- [Issue 150](https://github.com/veeso/termscp/issues/150)
+  - fixed config directory not being created
+  - before setting default ssh config path; check wheter it actually exists
 
 ## 0.11.0
 

--- a/src/config/params.rs
+++ b/src/config/params.rs
@@ -52,8 +52,15 @@ impl Default for RemoteConfig {
         let mut ssh_config_path = "~/.ssh/config".to_string();
         ssh_config_path = ssh_config_path.replacen('~', &home_dir.to_string_lossy(), 1);
 
+        // check if ssh config path exists first
+        let ssh_config_path = if PathBuf::from(&ssh_config_path).exists() {
+            Some(ssh_config_path)
+        } else {
+            None
+        };
+
         Self {
-            ssh_config: Some(ssh_config_path),
+            ssh_config: ssh_config_path,
             ssh_keys: HashMap::default(),
         }
     }

--- a/src/system/config_client.rs
+++ b/src/system/config_client.rs
@@ -645,7 +645,7 @@ mod tests {
     }
 
     #[test]
-    fn test_system_config_remote_ssh_config() {
+    fn should_get_and_set_ssh_config_dir() {
         let tmp_dir: TempDir = TempDir::new().ok().unwrap();
         let (cfg_path, key_path): (PathBuf, PathBuf) = get_paths(tmp_dir.path());
         let mut client: ConfigClient = ConfigClient::new(cfg_path.as_path(), key_path.as_path())
@@ -655,7 +655,14 @@ mod tests {
         let home_dir = dirs::home_dir().unwrap_or_else(|| PathBuf::from("/root"));
         let mut ssh_config_path = "~/.ssh/config".to_string();
         ssh_config_path = ssh_config_path.replacen('~', &home_dir.to_string_lossy(), 1);
-        assert_eq!(client.get_ssh_config(), Some(ssh_config_path.as_str())); // Null ?
+
+        let ssh_config_path = if PathBuf::from(&ssh_config_path).exists() {
+            Some(ssh_config_path)
+        } else {
+            None
+        };
+
+        assert_eq!(client.get_ssh_config(), ssh_config_path.as_deref()); // Null ?
         client.set_ssh_config(Some(String::from("/tmp/ssh_config")));
         assert_eq!(client.get_ssh_config(), Some("/tmp/ssh_config"));
         client.set_ssh_config(None);

--- a/src/system/environment.rs
+++ b/src/system/environment.rs
@@ -25,12 +25,13 @@ pub fn init_config_dir() -> Result<Option<PathBuf>, String> {
         // Append termscp dir
         p.push("termscp/");
         // If directory doesn't exist, create it
-        match p.exists() {
-            true => Ok(Some(p)),
-            false => match std::fs::create_dir(p.as_path()) {
-                Ok(_) => Ok(Some(p)),
-                Err(err) => Err(err.to_string()),
-            },
+        if p.exists() {
+            return Ok(Some(p));
+        }
+        // directory doesn't exist; create dir recursively
+        match std::fs::create_dir_all(p.as_path()) {
+            Ok(_) => Ok(Some(p)),
+            Err(err) => Err(err.to_string()),
         }
     } else {
         Ok(None)


### PR DESCRIPTION
# 150 - issues with configuration

Fixes #150

## Description

- init_config_dir: use `create_dir_all` instead of `create_dir` in order to create `.config/` if it doesn't exist yet.
- before setting default ssh config path; check wheter it actually exists

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [x] regression test: config dir is created if it doesn't exist
- [x] regression test: config dir is accessed if it already exists
- [x] config dir is created recursively if parent doesn't exist yet
