### PR TITLE
bump remotefs-ssh to 0.1.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,12 +78,12 @@ with-keyring = [ "keyring" ]
 [target."cfg(target_family = \"windows\")"]
 [target."cfg(target_family = \"windows\")".dependencies]
 remotefs-ftp = { version = "^0.1.2", features = [ "native-tls" ] }
-remotefs-ssh = "^0.1.3"
+remotefs-ssh = "^0.1.5"
 
 [target."cfg(target_family = \"unix\")"]
 [target."cfg(target_family = \"unix\")".dependencies]
 remotefs-ftp = { version = "^0.1.2", features = [ "vendored", "native-tls" ] }
-remotefs-ssh = { version = "^0.1.3", features = [ "ssh2-vendored" ] }
+remotefs-ssh = { version = "^0.1.5", features = [ "ssh2-vendored" ] }
 users = "0.11.0"
 
 [profile.dev]


### PR DESCRIPTION
# ISSUE 154 - Wrong path in SCP

Fixes #154

## Description

- bump remotefs-ssh to 0.1.5

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

