### PR TITLE
fix: relative paths windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -267,9 +267,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.1.0"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c70beb79cbb5ce9c4f8e20849978f34225931f665bb49efa6982875a4d5facb3"
+checksum = "07d1372b52fa64b8af7cf6e3848cfa2dadb81c21e810f144bdd9c26e21895235"
 
 [[package]]
 name = "block"
@@ -1482,9 +1482,9 @@ dependencies = [
 
 [[package]]
 name = "linux-raw-sys"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d59d8c75012853d2e872fb56bc8a2e53718e2cafe1a4c823143141c6d90c322f"
+checksum = "3f508063cc7bb32987c71511216bd5a32be15bccb6a80b52df8b9d7f01fc3aa2"
 
 [[package]]
 name = "lock_api"
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "remotefs-ssh"
-version = "0.1.5"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dc949a6747835d440afadec5a51842d063047c355fbe1960adc322108587d94"
+checksum = "abb129fa52cebd0cc979b30ab80c4db7a1e37486c7bea9d5c81cc9e19f94d7ab"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -2392,9 +2392,9 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.37.11"
+version = "0.37.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85597d61f83914ddeba6a47b3b8ffe7365107221c2e557ed94426489fefb5f77"
+checksum = "722529a737f5a942fdbac3a46cee213053196737c5eaa3386d52e85b786f2659"
 dependencies = [
  "bitflags 1.3.2",
  "errno",
@@ -2894,7 +2894,7 @@ name = "termscp"
 version = "0.11.2"
 dependencies = [
  "argh",
- "bitflags 2.1.0",
+ "bitflags 2.2.0",
  "bytesize",
  "chrono",
  "content_inspector",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,12 +78,12 @@ with-keyring = [ "keyring" ]
 [target."cfg(target_family = \"windows\")"]
 [target."cfg(target_family = \"windows\")".dependencies]
 remotefs-ftp = { version = "^0.1.2", features = [ "native-tls" ] }
-remotefs-ssh = "^0.1.5"
+remotefs-ssh = "^0.1.6"
 
 [target."cfg(target_family = \"unix\")"]
 [target."cfg(target_family = \"unix\")".dependencies]
 remotefs-ftp = { version = "^0.1.2", features = [ "vendored", "native-tls" ] }
-remotefs-ssh = { version = "^0.1.5", features = [ "ssh2-vendored" ] }
+remotefs-ssh = { version = "^0.1.6", features = [ "ssh2-vendored" ] }
 users = "0.11.0"
 
 [profile.dev]


### PR DESCRIPTION
# ISSUE 166 - Can not make directory in current path with scp protocol

Fixes #166

## Description

- remotefs-ssh 0.1.6

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

