### PR TITLE
allow unknown fields in ssh2 configuration file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ Released on ??
 
 - [Issue 153](https://github.com/veeso/termscp/issues/153): show a loading message when loading directory's content
 - [Issue 176](https://github.com/veeso/termscp/issues/176): debug log is now written to CACHE_DIR
+- [Issue 173](https://github.com/veeso/termscp/issues/173): allow unknown fields in ssh2 configuration file
 
 ## 0.11.3
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2261,9 +2261,9 @@ dependencies = [
 
 [[package]]
 name = "remotefs-ssh"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abb129fa52cebd0cc979b30ab80c4db7a1e37486c7bea9d5c81cc9e19f94d7ab"
+checksum = "6b9bebc0c117c79679d55bd3bbe857ecc2f398eed678b593a9440138a1e6c05b"
 dependencies = [
  "chrono",
  "lazy_static",
@@ -2768,11 +2768,12 @@ dependencies = [
 
 [[package]]
 name = "ssh2-config"
-version = "0.1.6"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "65a664be1af7787264859a2a9272596fac07f0aeea6de56ca96f75aa82932a0f"
+checksum = "e31d9bb8e97972d6541ccf32ed51294e4e16feeef06a0e77a6272d041f0f5bc7"
 dependencies = [
- "dirs 4.0.0",
+ "bitflags 2.2.0",
+ "dirs 5.0.0",
  "thiserror",
  "wildmatch",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ rpassword = "^7.0"
 self_update = { version = "^0.36", default-features = false, features = [ "rustls", "archive-tar", "archive-zip", "compression-flate2", "compression-zip-deflate" ] }
 serde = { version = "^1", features = [ "derive" ] }
 simplelog = "^0.12"
-ssh2-config = "^0.1.6"
+ssh2-config = "^0.2"
 tempfile = "^3.4"
 thiserror = "^1"
 toml = "^0.7"
@@ -78,12 +78,12 @@ with-keyring = [ "keyring" ]
 [target."cfg(target_family = \"windows\")"]
 [target."cfg(target_family = \"windows\")".dependencies]
 remotefs-ftp = { version = "^0.1.2", features = [ "native-tls" ] }
-remotefs-ssh = "^0.1.6"
+remotefs-ssh = "^0.2"
 
 [target."cfg(target_family = \"unix\")"]
 [target."cfg(target_family = \"unix\")".dependencies]
 remotefs-ftp = { version = "^0.1.2", features = [ "vendored", "native-tls" ] }
-remotefs-ssh = { version = "^0.1.6", features = [ "ssh2-vendored" ] }
+remotefs-ssh = { version = "^0.2", features = [ "ssh2-vendored" ] }
 users = "0.11.0"
 
 [profile.dev]

--- a/src/filetransfer/builder.rs
+++ b/src/filetransfer/builder.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use remotefs::RemoteFs;
 use remotefs_aws_s3::AwsS3Fs;
 use remotefs_ftp::FtpFs;
-use remotefs_ssh::{ScpFs, SftpFs, SshOpts};
+use remotefs_ssh::{ScpFs, SftpFs, SshConfigParseRule, SshOpts};
 
 use super::params::{AwsS3Params, GenericProtocolParams};
 use super::{FileTransferProtocol, ProtocolParams};
@@ -110,7 +110,10 @@ impl Builder {
             opts = opts.password(password);
         }
         if let Some(config_path) = config_client.get_ssh_config() {
-            opts = opts.config_file(PathBuf::from(config_path));
+            opts = opts.config_file(
+                PathBuf::from(config_path),
+                SshConfigParseRule::ALLOW_UNKNOWN_FIELDS,
+            );
         }
         opts
     }

--- a/src/system/sshkey_storage.rs
+++ b/src/system/sshkey_storage.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 
 // Ext
-use remotefs_ssh::SshKeyStorage as SshKeyStorageTrait;
+use remotefs_ssh::{SshConfigParseRule, SshKeyStorage as SshKeyStorageTrait};
 use ssh2_config::SshConfig;
 
 use super::config_client::ConfigClient;
@@ -43,7 +43,7 @@ impl SshKeyStorage {
             .map_err(|e| format!("failed to open {path}: {e}"))
             .map(BufReader::new)?;
         SshConfig::default()
-            .parse(&mut reader)
+            .parse(&mut reader, SshConfigParseRule::ALLOW_UNKNOWN_FIELDS)
             .map_err(|e| format!("Failed to parse ssh2 config: {e}"))
     }
 


### PR DESCRIPTION
# ISSUE 173 - Allow unknown fields in ssh2 configuration file

Fixes #173

## Description

- allow unknown fields in ssh2 configuration file
- remotefs-ssh 0.2
- ssh2-config 0.2

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
