### PR TITLE
Brew Linux support

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@
 
 <p align="center">~ A feature rich terminal file transfer ~</p>
 <p align="center">
-  <a href="https://veeso.github.io/termscp/" target="_blank">Website</a>
+  <a href="https://termscp.veeso.dev/termscp/" target="_blank">Website</a>
   ·
-  <a href="https://veeso.github.io/termscp/#get-started" target="_blank">Installation</a>
+  <a href="https://termscp.veeso.dev/termscp/#get-started" target="_blank">Installation</a>
   ·
-  <a href="https://veeso.github.io/termscp/#user-manual" target="_blank">User manual</a>
+  <a href="https://termscp.veeso.dev/termscp/#user-manual" target="_blank">User manual</a>
 </p>
 
 <p align="center">
@@ -62,7 +62,7 @@
   /></a>
 </p>
 
-<p align="center">Developed by <a href="https://veeso.github.io/" target="_blank">@veeso</a></p>
+<p align="center">Developed by <a href="https://termscp.veeso.dev/" target="_blank">@veeso</a></p>
 <p align="center">Current version: 0.12.0 (19/04/2023)</p>
 
 <p align="center">
@@ -178,7 +178,7 @@ NetBSD users can install termscp from the official repositories.
 pkgin install termscp
 ```
 
-For more information or other platforms, please visit [veeso.github.io](https://veeso.github.io/termscp/#get-started) to view all installation methods.
+For more information or other platforms, please visit [termscp.veeso.dev](https://termscp.veeso.dev/termscp/#get-started) to view all installation methods.
 
 ⚠️ If you're looking on how to update termscp just run termscp from CLI with: `(sudo) termscp --update` ⚠️
 
@@ -223,7 +223,7 @@ You can make a donation with one of these platforms:
 
 ## User manual 📚
 
-The user manual can be found on the [termscp's website](https://veeso.github.io/termscp/#user-manual) or on [Github](docs/man.md).
+The user manual can be found on the [termscp's website](https://termscp.veeso.dev/termscp/#user-manual) or on [Github](docs/man.md).
 
 ---
 

--- a/dist/build/freebsd.sh
+++ b/dist/build/freebsd.sh
@@ -39,7 +39,7 @@ echo -e "desc: <<EOD\n\
     A feature rich terminal UI file transfer and explorer with support for SCP/SFTP/FTP/S3\n\
 EOD\n\
 arch: \"amd64\"\n\
-www: \"https://veeso.github.io/termscp/\"\n\
+www: \"https://termscp.veeso.dev/termscp/\"\n\
 maintainer: \"christian.visintin1997@gmail.com\"\n\
 prefix: \"/usr/local/bin\"\n\
 deps: {\n\

--- a/dist/build/linux-aarch64.sh
+++ b/dist/build/linux-aarch64.sh
@@ -44,6 +44,7 @@ docker stop "$ARM64_DEB_NAME"
 # Make tar.gz
 cd ${PKGS_DIR}/aarch64-unknown-linux-gnu/
 tar cvzf termscp-v${VERSION}-aarch64-unknown-linux-gnu.tar.gz termscp
+echo "Sha256 (homebrew aarch64): $(sha256sum termscp-v${VERSION}-aarch64-unknown-linux-gnu.tar.gz)"
 rm termscp
 cd -
 # Build aarch64_centos7

--- a/dist/build/linux-x86_64.sh
+++ b/dist/build/linux-x86_64.sh
@@ -44,6 +44,7 @@ docker stop "$X86_64_DEB_NAME"
 # Make tar.gz
 cd ${PKGS_DIR}/x86_64-unknown-linux-gnu/
 tar cvzf termscp-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz termscp
+echo "Sha256 x86_64 (homebrew): $(sha256sum termscp-v${VERSION}-x86_64-unknown-linux-gnu.tar.gz)"
 rm termscp
 cd -
 # Build x86_64_centos7

--- a/docs/de/README.md
+++ b/docs/de/README.md
@@ -6,11 +6,11 @@
 
 <p align="center">~ Eine funktionsreiche Terminal-Dateiübertragung ~</p>
 <p align="center">
-  <a href="https://veeso.github.io/termscp/" target="_blank">Webseite</a>
+  <a href="https://termscp.veeso.dev/termscp/" target="_blank">Webseite</a>
   ·
-  <a href="https://veeso.github.io/termscp/#get-started" target="_blank">Installation</a>
+  <a href="https://termscp.veeso.dev/termscp/#get-started" target="_blank">Installation</a>
   ·
-  <a href="https://veeso.github.io/termscp/#user-manual" target="_blank">Benutzerhandbuch</a>
+  <a href="https://termscp.veeso.dev/termscp/#user-manual" target="_blank">Benutzerhandbuch</a>
 </p>
 
 <p align="center">
@@ -62,7 +62,7 @@
   /></a>
 </p>
 
-<p align="center">Entwickelt von <a href="https://veeso.github.io/" target="_blank">@veeso</a></p>
+<p align="center">Entwickelt von <a href="https://termscp.veeso.dev/" target="_blank">@veeso</a></p>
 <p align="center">Aktuelle Version: 0.12.0 (19/04/2023)</p>
 
 <p align="center">
@@ -175,7 +175,7 @@ Wenn Sie ein Windows-Benutzer sind, können Sie termscp mit [Chocolatey](https:/
 choco install termscp
 ```
 
-Für weitere Informationen oder andere Plattformen besuchen Sie bitte [veeso.github.io](https://veeso.github.io/termscp/#get-started), um alle Installationsmethoden anzuzeigen.
+Für weitere Informationen oder andere Plattformen besuchen Sie bitte [termscp.veeso.dev](https://termscp.veeso.dev/termscp/#get-started), um alle Installationsmethoden anzuzeigen.
 
 ⚠️ Wenn Sie wissen möchten, wie Sie termscp aktualisieren können, führen Sie einfach termscp über die CLI aus mit: `(sudo) termscp --update` ⚠️
 
@@ -221,7 +221,7 @@ Sie können mit einer dieser Plattformen spenden:
 
 ## User manual 📚
 
-Das Benutzerhandbuch finden Sie auf der [termscp-Website](https://veeso.github.io/termscp/#user-manual) oder auf [Github](man.md).
+Das Benutzerhandbuch finden Sie auf der [termscp-Website](https://termscp.veeso.dev/termscp/#user-manual) oder auf [Github](man.md).
 
 ---
 

--- a/docs/es/README.md
+++ b/docs/es/README.md
@@ -6,11 +6,11 @@
 
 <p align="center">~ Una transferencia de archivos de terminal rica en funciones ~</p>
 <p align="center">
-  <a href="https://veeso.github.io/termscp/" target="_blank">Sitio Web</a>
+  <a href="https://termscp.veeso.dev/termscp/" target="_blank">Sitio Web</a>
   ·
-  <a href="https://veeso.github.io/termscp/#get-started" target="_blank">Instalación</a>
+  <a href="https://termscp.veeso.dev/termscp/#get-started" target="_blank">Instalación</a>
   ·
-  <a href="https://veeso.github.io/termscp/#user-manual" target="_blank">Manual de usuario</a>
+  <a href="https://termscp.veeso.dev/termscp/#user-manual" target="_blank">Manual de usuario</a>
 </p>
 
 <p align="center">
@@ -62,7 +62,7 @@
   /></a>
 </p>
 
-<p align="center">Desarrollado por <a href="https://veeso.github.io/" target="_blank">@veeso</a></p>
+<p align="center">Desarrollado por <a href="https://termscp.veeso.dev/" target="_blank">@veeso</a></p>
 <p align="center">Versión actual: 0.12.0 (19/04/2023)</p>
 
 <p align="center">
@@ -175,7 +175,7 @@ mientras que si eres un usuario de Windows, puedes instalar termscp con [Chocola
 choco install termscp
 ```
 
-Para obtener más información u otras plataformas, visite [veeso.github.io](https://veeso.github.io/termscp/#get-started) para ver todos los métodos de instalación.
+Para obtener más información u otras plataformas, visite [termscp.veeso.dev](https://termscp.veeso.dev/termscp/#get-started) para ver todos los métodos de instalación.
 
 ⚠️ Si estás buscando cómo actualizar termscp, simplemente ejecute termscp desde CLI con:: `(sudo) termscp --update` ⚠️
 
@@ -221,7 +221,7 @@ Puedes hacer una donación con una de estas plataformas:
 
 ## Manual de usuario y documentación 📚
 
-El manual del usuario se puede encontrar en el [sitio web de termscp](https://veeso.github.io/termscp/#user-manual) o en [Github](man.md).
+El manual del usuario se puede encontrar en el [sitio web de termscp](https://termscp.veeso.dev/termscp/#user-manual) o en [Github](man.md).
 
 ---
 

--- a/docs/fr/README.md
+++ b/docs/fr/README.md
@@ -6,11 +6,11 @@
 
 <p align="center">~ Un file transfer de terminal riche en fonctionnalités ~</p>
 <p align="center">
-  <a href="https://veeso.github.io/termscp/" target="_blank">Site internet</a>
+  <a href="https://termscp.veeso.dev/termscp/" target="_blank">Site internet</a>
   ·
-  <a href="https://veeso.github.io/termscp/#get-started" target="_blank">Installation</a>
+  <a href="https://termscp.veeso.dev/termscp/#get-started" target="_blank">Installation</a>
   ·
-  <a href="https://veeso.github.io/termscp/#user-manual" target="_blank">Manuel de l'Utilisateur</a>
+  <a href="https://termscp.veeso.dev/termscp/#user-manual" target="_blank">Manuel de l'Utilisateur</a>
 </p>
 
 <p align="center">
@@ -62,7 +62,7 @@
   /></a>
 </p>
 
-<p align="center">Développé par <a href="https://veeso.github.io/" target="_blank">@veeso</a></p>
+<p align="center">Développé par <a href="https://termscp.veeso.dev/" target="_blank">@veeso</a></p>
 <p align="center">Version actuelle: 0.12.0 (19/04/2023)</p>
 
 <p align="center">
@@ -175,7 +175,7 @@ tandis que si tu es un utilisateur Windows, tu peux installer termscp avec [Choc
 choco install termscp
 ```
 
-Pour plus d'informations sur les autres méthodes d'installation, veuillez visiter [veeso.github.io](https://veeso.github.io/termscp/#get-started).
+Pour plus d'informations sur les autres méthodes d'installation, veuillez visiter [termscp.veeso.dev](https://termscp.veeso.dev/termscp/#get-started).
 
 ⚠️ Si tu cherche comme de mettre à jour termscp, tu dois exécuter cette commande dans le terminal: `(sudo) termscp --update` ⚠️
 
@@ -221,7 +221,7 @@ Tu peux faire un don avec l'une de ces plateformes:
 
 ## Manuel d'utilisateur et Documentation 📚
 
-Le manuel d'utilisateur peut être trouvé sur le [site de termscp](https://veeso.github.io/termscp/#user-manual) ou sur [Github](man.md).
+Le manuel d'utilisateur peut être trouvé sur le [site de termscp](https://termscp.veeso.dev/termscp/#user-manual) ou sur [Github](man.md).
 
 La documentation peut être trouvé sur Rust Docs <https://docs.rs/termscp>
 

--- a/docs/it/README.md
+++ b/docs/it/README.md
@@ -6,11 +6,11 @@
 
 <p align="center">~ Un file transfer ricco di funzionalità ~</p>
 <p align="center">
-  <a href="https://veeso.github.io/termscp/" target="_blank">Sito</a>
+  <a href="https://termscp.veeso.dev/termscp/" target="_blank">Sito</a>
   ·
-  <a href="https://veeso.github.io/termscp/#get-started" target="_blank">Installazione</a>
+  <a href="https://termscp.veeso.dev/termscp/#get-started" target="_blank">Installazione</a>
   ·
-  <a href="https://veeso.github.io/termscp/#user-manual" target="_blank">Manuale utente</a>
+  <a href="https://termscp.veeso.dev/termscp/#user-manual" target="_blank">Manuale utente</a>
 </p>
 
 <p align="center">
@@ -62,7 +62,7 @@
   /></a>
 </p>
 
-<p align="center">Sviluppato da <a href="https://veeso.github.io/" target="_blank">@veeso</a></p>
+<p align="center">Sviluppato da <a href="https://termscp.veeso.dev/" target="_blank">@veeso</a></p>
 <p align="center">Versione corrente: 0.12.0 (19/04/2023)</p>
 
 <p align="center">
@@ -175,7 +175,7 @@ mentre se sei un utente Windows, puoi installare termscp con [Chocolatey](https:
 choco install termscp
 ```
 
-Per ulteriori informazioni sui metodi di installazione su altre piattaforme, visita [veeso.github.io](https://veeso.github.io/termscp/#get-started).
+Per ulteriori informazioni sui metodi di installazione su altre piattaforme, visita [termscp.veeso.dev](https://termscp.veeso.dev/termscp/#get-started).
 
 ⚠️  Se stavi cercando come aggiornare la tua versione di termscp, puoi semplicemente lanciare termscp con questi argomenti: `(sudo) termscp --update` ⚠️
 
@@ -221,7 +221,7 @@ Puoi fare una donazione tramite una di queste piattaforme:
 
 ## Manuale utente 📚
 
-Il manuale utente lo puoi trovare sul [sito di termscp](https://veeso.github.io/termscp/#user-manual) o su [Github](man.md).
+Il manuale utente lo puoi trovare sul [sito di termscp](https://termscp.veeso.dev/termscp/#user-manual) o su [Github](man.md).
 
 ---
 

--- a/docs/zh-CN/README.md
+++ b/docs/zh-CN/README.md
@@ -6,11 +6,11 @@
 
 <p align="center">~ 功能丰富的终端文件传输工具 ~</p>
 <p align="center">
-  <a href="https://veeso.github.io/termscp/" target="_blank">网站</a>
+  <a href="https://termscp.veeso.dev/termscp/" target="_blank">网站</a>
   ·
-  <a href="https://veeso.github.io/termscp/#get-started" target="_blank">安装</a>
+  <a href="https://termscp.veeso.dev/termscp/#get-started" target="_blank">安装</a>
   ·
-  <a href="https://veeso.github.io/termscp/#user-manual" target="_blank">用户手册</a>
+  <a href="https://termscp.veeso.dev/termscp/#user-manual" target="_blank">用户手册</a>
 </p>
 
 <p align="center">
@@ -62,7 +62,7 @@
   /></a>
 </p>
 
-<p align="center">由 <a href="https://veeso.github.io/" target="_blank">@veeso</a> 开发</p>
+<p align="center">由 <a href="https://termscp.veeso.dev/" target="_blank">@veeso</a> 开发</p>
 <p align="center">当前版本： 0.12.0 (19/04/2023)</p>
 
 <p align="center">
@@ -178,7 +178,7 @@ curl -sSLf http://get-termscp.veeso.dev | sh
 choco install termscp
 ```
 
-如需更多信息或其他的平台支持，请访问 [veeso.github.io](https://veeso.github.io/termscp/#get-started) 查看所有安装方法。
+如需更多信息或其他的平台支持，请访问 [termscp.veeso.dev](https://termscp.veeso.dev/termscp/#get-started) 查看所有安装方法。
 
 ⚠️ 如果您正在寻找如何更新 termscp 只需从 CLI 运行 termscp ： `(sudo) termscp --update` ⚠️
 
@@ -225,7 +225,7 @@ choco install termscp
 
 ## 用户手册和文档 📚
 
-用户手册可以在[termscp的网站](https://veeso.github.io/termscp/#user-manual)或者在[Github](man.md)上找到。
+用户手册可以在[termscp的网站](https://termscp.veeso.dev/termscp/#user-manual)或者在[Github](man.md)上找到。
 
 ---
 

--- a/install.sh
+++ b/install.sh
@@ -476,8 +476,8 @@ case $PLATFORM in
 esac
 
 completed "Congratulations! Termscp has successfully been installed on your system!"
-info "If you're a new user, you might be interested in reading the user manual <https://veeso.github.io/termscp/#user-manual>"
-info "While if you've just updated your termscp version, you can find the changelog at this link <https://veeso.github.io/termscp/#changelog>"
+info "If you're a new user, you might be interested in reading the user manual <https://termscp.veeso.dev/termscp/#user-manual>"
+info "While if you've just updated your termscp version, you can find the changelog at this link <https://termscp.veeso.dev/termscp/#changelog>"
 info "Remember that if you encounter any issue, you can report them on Github <https://github.com/veeso/termscp/issues/new>"
 info "Feel free to open an issue also if you have an idea which could improve the project"
 info "If you want to support the project, please, consider a little donation <https://ko-fi.com/veeso>"

--- a/install.sh
+++ b/install.sh
@@ -209,6 +209,18 @@ install_on_arch_linux() {
     $pkg -S termscp
 }
 
+install_with_brew() {
+    info "Installing termscp with brew"
+    if has termscp; then
+        info "Upgrading ${GREEN}termscp${NO_COLOR}…"
+        # The OR is used since someone could have installed via cargo previously
+        brew update && brew upgrade termscp || brew install veeso/termscp/termscp
+    else
+        info "Installing ${GREEN}termscp${NO_COLOR}…"
+        brew install veeso/termscp/termscp
+    fi
+}
+
 install_on_linux() {
     local msg
     local sudo
@@ -271,6 +283,8 @@ install_on_linux() {
         info "$msg"
         $sudo rpm -U "${archive}"
         rm -f ${archive}
+    elif has brew; then
+        install_with_brew
     else
         try_with_cargo "No suitable installation method found for your Linux distribution; if you're running on Arch linux, please install an AUR package manager (such as yay). Currently only Arch, Debian based and Red Hat based distros are supported" "linux"
     fi
@@ -278,23 +292,7 @@ install_on_linux() {
 
 install_on_macos() {
     if has brew; then
-        # get homebrew formula name
-        if [ "${ARCH}" == "x86_64" ]; then
-            FORMULA="termscp"
-        elif [ "$ARCH" == "aarch64" ]; then
-            FORMULA="termscp-m1"
-        else
-            error "unsupported arch: $ARCH"
-            exit 1
-        fi
-        if has termscp; then
-            info "Upgrading ${GREEN}termscp${NO_COLOR}…"
-            # The OR is used since someone could have installed via cargo previously
-            brew update && brew upgrade ${FORMULA} || brew install veeso/termscp/${FORMULA}
-        else
-            info "Installing ${GREEN}termscp${NO_COLOR}…"
-            brew install veeso/termscp/${FORMULA}
-        fi
+        install_with_brew
     else
         try_with_cargo "brew is missing on your system; please install it from <https://brew.sh/>" "macos"
     fi

--- a/site/html/get-started.html
+++ b/site/html/get-started.html
@@ -1,23 +1,19 @@
 <head>
   <link rel="stylesheet" href="css/get-started.css" />
 </head>
+
 <body>
   <section id="start" class="container start">
     <h1 translate="getStarted.title">Get started</h1>
     <section>
       <h2>
-        <i class="fa fa-rocket"></i>&nbsp;<span
-          translate="getStarted.quickSetup"
-          >Quick setup</span
-        >
+        <i class="fa fa-rocket"></i>&nbsp;<span translate="getStarted.quickSetup">Quick setup</span>
       </h2>
       <div class="installation">
         <div class="alert alert-primary">
           <p>
             <i class="fas fa-info-circle"></i>
-            <span translate="getStarted.suggested"
-              >We strongly suggest this method to install termscp</span
-            >
+            <span translate="getStarted.suggested">We strongly suggest this method to install termscp</span>
           </p>
         </div>
         <p translate="getStarted.posixUsers">
@@ -29,80 +25,52 @@
     </section>
     <section>
       <h2>
-        <i class="devicon-windows8-plain"></i>&nbsp;<span
-          translate="getStarted.windows.title"
-          >Windows users</span
-        >
+        <i class="devicon-windows8-plain"></i>&nbsp;<span translate="getStarted.windows.title">Windows users</span>
       </h2>
       <div class="installation">
         <p>
-          <span translate="getStarted.windows.intro"
-            >You can install termscp on Windows via</span
-          >
-          <a
-            href="https://community.chocolatey.org/packages/termscp"
-            target="_blank"
-            >Chocolatey</a
-          >
+          <span translate="getStarted.windows.intro">You can install termscp on Windows via</span>
+          <a href="https://community.chocolatey.org/packages/termscp" target="_blank">Chocolatey</a>
         </p>
         <pre><span class="function">choco</span> install <span class="string">termscp</span></pre>
         <p>
-          <span translate="getStarted.windows.moderation"
-            >Consider that Chocolatey moderation can take up to a few weeks
+          <span translate="getStarted.windows.moderation">Consider that Chocolatey moderation can take up to a few weeks
             since last release, so if the latest version is not available yet,
-            you can install it downloading the ZIP file from</span
-          >
-          <a
-            href="https://github.com/veeso/termscp/releases/latest/download/termscp.0.12.0.nupkg"
-            target="_blank"
-            >Github</a
-          >
-          <span translate="getStarted.windows.then"
-            >and then, from the ZIP directory, install it via</span
-          >
+            you can install it downloading the ZIP file from</span>
+          <a href="https://github.com/veeso/termscp/releases/latest/download/termscp.0.12.0.nupkg"
+            target="_blank">Github</a>
+          <span translate="getStarted.windows.then">and then, from the ZIP directory, install it via</span>
         </p>
         <pre><span class="function">choco</span> install <span class="string">termscp</span> -s .</pre>
       </div>
     </section>
     <section>
       <h2>
-        <i class="devicon-linux-plain"></i>&nbsp;<span
-          translate="getStarted.linuxUsers"
-          >Linux users</span
-        >
+        <i class="devicon-linux-plain"></i>&nbsp;<span translate="getStarted.linuxUsers">Linux users</span>
       </h2>
       <div class="sub-system">
         <div class="alert alert-warning">
           <p>
             <i class="fas fa-exclamation-triangle"></i>
-            <span translate="getStarted.notConfident"
-              >Opt for these methods instead if you don't feel confident using
-              the shell script</span
-            >
+            <span translate="getStarted.notConfident">Opt for these methods instead if you don't feel confident using
+              the shell script</span>
           </p>
         </div>
         <h3>
-          <i class="devicon-linux-plain"></i>&nbsp;<span
-            translate="getStarted.arch.title"
-            >Arch derived users</span
-          >
+          <i class="devicon-linux-plain"></i>&nbsp;<span translate="getStarted.arch.title">Arch derived users</span>
         </h3>
         <div class="installation">
           <p>
-            <span translate="getStarted.arch.intro"
-              >On Arch Linux based distros, you can install termscp using an AUR
-              package manager such as</span
-            >
+            <span translate="getStarted.arch.intro">On Arch Linux based distros, you can install termscp using an AUR
+              package manager such as</span>
             <a href="https://github.com/Jguer/yay" target="_blank">yay</a>
             <span translate="getStarted.arch.then">then run:</span>
           </p>
           <pre><span class="function">yay</span> -S <span class="string">termscp</span></pre>
         </div>
         <h3>
-          <i class="devicon-debian-plain"></i>&nbsp;<span
-            translate="getStarted.debian.title"
-            >Debian derived users</span
-          >
+          <i class="devicon-debian-plain"></i>&nbsp;<span translate="getStarted.debian.title">Debian derived
+            users</span>
         </h3>
         <div class="installation">
           <p translate="getStarted.debian.body">
@@ -113,10 +81,8 @@
 sudo <span class="function">dpkg</span> -i <span class="string">termscp.deb</span></pre>
         </div>
         <h3>
-          <i class="devicon-redhat-plain"></i>&nbsp;<span
-            translate="getStarted.redhat.title"
-            >Redhat derived users</span
-          >
+          <i class="devicon-redhat-plain"></i>&nbsp;<span translate="getStarted.redhat.title">Redhat derived
+            users</span>
         </h3>
         <div class="installation">
           <p translate="getStarted.redhat.body">
@@ -126,28 +92,32 @@ sudo <span class="function">dpkg</span> -i <span class="string">termscp.deb</spa
           <pre><span class="function">wget</span> -O termscp.rpm <span class="string">https://github.com/veeso/termscp/releases/latest/download/termscp-0.12.0-1.x86_64.rpm</span>
 sudo <span class="function">rpm</span> -U <span class="string">termscp.rpm</span></pre>
         </div>
+        <h3>
+          <span>Brew</span>
+        </h3>
+        <div class="installation">
+          <p>
+            <span translate="getStarted.macos.install">Install termscp via</span>&nbsp;
+            <a href="https://brew.sh/" target="_blank">Brew</a>
+          </p>
+          <pre><span class="function">brew</span> install <span class="string">veeso/termscp/termscp</span></pre>
+        </div>
       </div>
     </section>
     <section>
       <h2>
-        <i class="devicon-apple-plain"></i>&nbsp;<span
-          translate="getStarted.macos.title"
-          >MacOS users</span
-        >
+        <i class="devicon-apple-plain"></i>&nbsp;<span translate="getStarted.macos.title">MacOS users</span>
       </h2>
       <div class="installation">
         <div class="alert alert-warning">
           <p>
             <i class="fas fa-exclamation-triangle"></i>
-            <span translate="getStarted.notConfident"
-              >Opt for this method instead if you don't feel confident using the
-              shell script</span
-            >
+            <span translate="getStarted.notConfident">Opt for this method instead if you don't feel confident using the
+              shell script</span>
           </p>
         </div>
         <p>
-          <span translate="getStarted.macos.install">Install termscp via</span
-          >&nbsp;
+          <span translate="getStarted.macos.install">Install termscp via</span>&nbsp;
           <a href="https://brew.sh/" target="_blank">Brew</a>
         </p>
         <pre><span class="function">brew</span> install <span class="string">veeso/termscp/termscp</span></pre>
@@ -155,33 +125,22 @@ sudo <span class="function">rpm</span> -U <span class="string">termscp.rpm</span
     </section>
     <section>
       <h2>
-        <i class="devicon-rust-plain"></i>&nbsp;<span
-          translate="getStarted.cargo.title"
-          >Install with Cargo</span
-        >
+        <i class="devicon-rust-plain"></i>&nbsp;<span translate="getStarted.cargo.title">Install with Cargo</span>
       </h2>
       <div class="installation">
         <div class="alert alert-warning">
           <p>
             <i class="fas fa-exclamation-triangle"></i>
-            <span translate="getStarted.noBinary"
-              >Opt for this method instead if binaries for your platform are not
-              available</span
-            >
+            <span translate="getStarted.noBinary">Opt for this method instead if binaries for your platform are not
+              available</span>
           </p>
         </div>
         <p>
-          <span translate="getStarted.cargo.body"
-            >If a package is not available for your system, you can opt to
-            install termscp via</span
-          >&nbsp;
-          <a href="https://www.rust-lang.org/tools/install" target="_blank"
-            >Cargo</a
-          >.
-          <span translate="getStarted.cargo.requirements"
-            >To install termscp via Cargo, these requirements must be
-            satisfied:</span
-          >
+          <span translate="getStarted.cargo.body">If a package is not available for your system, you can opt to
+            install termscp via</span>&nbsp;
+          <a href="https://www.rust-lang.org/tools/install" target="_blank">Cargo</a>.
+          <span translate="getStarted.cargo.requirements">To install termscp via Cargo, these requirements must be
+            satisfied:</span>
         </p>
         <ul>
           <li>

--- a/site/html/updates.html
+++ b/site/html/updates.html
@@ -24,7 +24,7 @@
           Termscp is an application that is still in its early stage of
           development, the first version has been released in december in 2020
           and practically there's only one
-          <a href="https://veeso.github.io/" target="_blank">guy</a> working on
+          <a href="https://termscp.veeso.dev/" target="_blank">guy</a> working on
           it and there's still a lot of work to do in order to improve it and
           make it fast and reliable. Along to this, you should also consider
           that since it's an application which works with network protocols and


### PR DESCRIPTION
# ISSUE 174 - Brew Linux support

Fixes #174 

## Description

- Added brew to install script
- Removed `termscp-m1` formula. Everything has been merged in a single formula.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

