### PR TITLE
Don't prompt for password if a ssh key is set for that host

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Released on ??
 - [Issue 153](https://github.com/veeso/termscp/issues/153): show a loading message when loading directory's content
 - [Issue 176](https://github.com/veeso/termscp/issues/176): debug log is now written to CACHE_DIR
 - [Issue 173](https://github.com/veeso/termscp/issues/173): allow unknown fields in ssh2 configuration file
+- [Issue 175](https://github.com/veeso/termscp/issues/175): don't prompt for password if a ssh key is set for that host
+- Fixed an issue that didn't use the `User` specified in ssh2-config
 
 ## 0.11.3
 

--- a/src/filetransfer/params.rs
+++ b/src/filetransfer/params.rs
@@ -107,7 +107,6 @@ impl Default for ProtocolParams {
 }
 
 impl ProtocolParams {
-    #[cfg(test)]
     /// Retrieve generic parameters from protocol params if any
     pub fn generic_params(&self) -> Option<&GenericProtocolParams> {
         match self {

--- a/src/ui/activities/filetransfer/view.rs
+++ b/src/ui/activities/filetransfer/view.rs
@@ -153,7 +153,16 @@ impl FileTransferActivity {
             self.app.view(&Id::StatusBarLocal, f, status_bar_chunks[0]);
             self.app.view(&Id::StatusBarRemote, f, status_bar_chunks[1]);
             // @! Draw popups
-            if self.app.mounted(&Id::CopyPopup) {
+            if self.app.mounted(&Id::FatalPopup) {
+                let popup = Popup(
+                    Size::Percentage(50),
+                    self.calc_popup_height(Id::FatalPopup, f.size().width, f.size().height),
+                )
+                .draw_in(f.size());
+                f.render_widget(Clear, popup);
+                // make popup
+                self.app.view(&Id::FatalPopup, f, popup);
+            } else if self.app.mounted(&Id::CopyPopup) {
                 let popup = Popup(Size::Percentage(40), Size::Unit(3)).draw_in(f.size());
                 f.render_widget(Clear, popup);
                 // make popup
@@ -292,15 +301,6 @@ impl FileTransferActivity {
                 f.render_widget(Clear, popup);
                 // make popup
                 self.app.view(&Id::ErrorPopup, f, popup);
-            } else if self.app.mounted(&Id::FatalPopup) {
-                let popup = Popup(
-                    Size::Percentage(50),
-                    self.calc_popup_height(Id::FatalPopup, f.size().width, f.size().height),
-                )
-                .draw_in(f.size());
-                f.render_widget(Clear, popup);
-                // make popup
-                self.app.view(&Id::FatalPopup, f, popup);
             } else if self.app.mounted(&Id::WaitPopup) {
                 let popup = Popup(Size::Percentage(50), Size::Unit(3)).draw_in(f.size());
                 f.render_widget(Clear, popup);
@@ -360,6 +360,7 @@ impl FileTransferActivity {
     }
 
     pub(super) fn mount_fatal<S: AsRef<str>>(&mut self, text: S) {
+        self.umount_wait();
         // Mount
         let error_color = self.theme().misc_error_dialog;
         assert!(self

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,6 +9,7 @@ pub mod fmt;
 pub mod parser;
 pub mod path;
 pub mod random;
+pub mod ssh;
 pub mod string;
 pub mod tty;
 pub mod ui;

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -196,16 +196,7 @@ fn parse_generic_remote_opt(
     match REMOTE_GENERIC_OPT_REGEX.captures(s) {
         Some(groups) => {
             // Match user
-            let username: Option<String> = match groups.get(1) {
-                Some(group) => Some(group.as_str().to_string()),
-                None => match protocol {
-                    // If group is empty, set to current user
-                    FileTransferProtocol::Scp | FileTransferProtocol::Sftp => {
-                        Some(whoami::username())
-                    }
-                    _ => None,
-                },
-            };
+            let username = groups.get(1).map(|x| x.as_str().to_string());
             // Get address
             let address: String = match groups.get(2) {
                 Some(group) => group.as_str().to_string(),
@@ -437,7 +428,7 @@ mod tests {
         assert_eq!(result.protocol, FileTransferProtocol::Sftp);
         assert_eq!(params.address, String::from("172.26.104.1"));
         assert_eq!(params.port, 22);
-        assert!(params.username.is_some());
+        assert!(params.username.is_none());
         // User case
         let result: FileTransferParams = parse_remote_opt(&String::from("root@172.26.104.1"))
             .ok()
@@ -472,7 +463,7 @@ mod tests {
         assert_eq!(result.protocol, FileTransferProtocol::Sftp);
         assert_eq!(params.address, String::from("172.26.104.1"));
         assert_eq!(params.port, 4022);
-        assert!(params.username.is_some());
+        assert!(params.username.is_none());
         assert!(result.entry_directory.is_none());
         // Protocol
         let result: FileTransferParams = parse_remote_opt(&String::from("ftp://172.26.104.1"))
@@ -492,7 +483,7 @@ mod tests {
         assert_eq!(result.protocol, FileTransferProtocol::Sftp);
         assert_eq!(params.address, String::from("172.26.104.1"));
         assert_eq!(params.port, 22); // Fallback to sftp default
-        assert!(params.username.is_some()); // Doesn't fall back
+        assert!(params.username.is_none()); // Doesn't fall back
         assert!(result.entry_directory.is_none());
         let result: FileTransferParams = parse_remote_opt(&String::from("scp://172.26.104.1"))
             .ok()
@@ -501,7 +492,7 @@ mod tests {
         assert_eq!(result.protocol, FileTransferProtocol::Scp);
         assert_eq!(params.address, String::from("172.26.104.1"));
         assert_eq!(params.port, 22); // Fallback to scp default
-        assert!(params.username.is_some()); // Doesn't fall back
+        assert!(params.username.is_none()); // Doesn't fall back
         assert!(result.entry_directory.is_none());
         // Protocol + user
         let result: FileTransferParams =
@@ -539,7 +530,7 @@ mod tests {
         assert_eq!(result.protocol, FileTransferProtocol::Sftp);
         assert_eq!(params.address, String::from("172.26.104.1"));
         assert_eq!(params.port, 22);
-        assert!(params.username.is_some());
+        assert!(params.username.is_none());
         assert_eq!(result.entry_directory.unwrap(), PathBuf::from("home"));
         // All together now
         let result: FileTransferParams =

--- a/src/utils/ssh.rs
+++ b/src/utils/ssh.rs
@@ -1,0 +1,45 @@
+use ssh2_config::{ParseRule, SshConfig};
+
+pub fn parse_ssh2_config(path: &str) -> Result<SshConfig, String> {
+    use std::fs::File;
+    use std::io::BufReader;
+
+    let mut reader = File::open(path)
+        .map_err(|e| format!("failed to open {path}: {e}"))
+        .map(BufReader::new)?;
+    SshConfig::default()
+        .parse(&mut reader, ParseRule::ALLOW_UNKNOWN_FIELDS)
+        .map_err(|e| format!("Failed to parse ssh2 config: {e}"))
+}
+
+#[cfg(test)]
+mod test {
+
+    use crate::utils::{ssh::parse_ssh2_config, test_helpers};
+
+    #[test]
+    fn should_parse_ssh2_config() {
+        let rsa_key = test_helpers::create_sample_file_with_content("ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQDErJhQxEI0+VvhlXVUyh+vMCm7aXfCA/g633AG8ezD/5EylwchtAr2JCoBWnxn4zV8nI9dMqOgm0jO4IsXpKOjQojv+0VOH7I+cDlBg0tk4hFlvyyS6YviDAfDDln3jYUM+5QNDfQLaZlH2WvcJ3mkDxLVlI9MBX1BAeSmChLxwAvxALp2ncImNQLzDO9eHcig3dtMrEKkzXQowRW5Y7eUzg2+vvVq4H2DOjWwUndvB5sJkhEfTUVE7ID8ZdGJo60kUb/02dZYj+IbkAnMCsqktk0cg/4XFX82hEfRYFeb1arkysFisPU1DOb6QielL/axeTebVplaouYcXY0pFdJt root@8c50fd4c345a");
+        let ssh_config_file = test_helpers::create_sample_file_with_content(format!(
+            r#"
+Host test
+        HostName 127.0.0.1
+        Port 2222
+        User test
+        IdentityFile {}
+        StrictHostKeyChecking no
+        UserKnownHostsFile /dev/null
+"#,
+            rsa_key.path().display()
+        ));
+
+        assert!(parse_ssh2_config(
+            ssh_config_file
+                .path()
+                .to_string_lossy()
+                .to_string()
+                .as_str()
+        )
+        .is_ok());
+    }
+}


### PR DESCRIPTION
# ISSUE 175 - Don't prompt for a password if a ssh key is set for that host

Fixes #175

## Description

- If a ssh key is found in ssh key storage in activity manager, don't prompt for password.

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
