### PR TITLE
Add missing row in KeybindingsPopup

### DIFF
--- a/src/ui/activities/filetransfer/components/popups.rs
+++ b/src/ui/activities/filetransfer/components/popups.rs
@@ -750,6 +750,7 @@ impl KeybindingsPopup {
                         .add_col(TextSpan::from(
                             "            Open text file with preferred editor",
                         ))
+                        .add_row()
                         .add_col(TextSpan::new("<P>").bold().fg(key_color))
                         .add_col(TextSpan::from("               Toggle log panel"))
                         .add_row()
@@ -785,6 +786,7 @@ impl KeybindingsPopup {
                         .add_col(TextSpan::from(
                             "               Toggle synchronized browsing",
                         ))
+                        .add_row()
                         .add_col(TextSpan::new("<Z>").bold().fg(key_color))
                         .add_col(TextSpan::from("               Change file permissions"))
                         .add_row()


### PR DESCRIPTION
# Add missing row in KeybindingsPopup

Fixes # Fix display issue in KeybindingsPopup due to missing line breaks.

## Description
Fix display issue in KeybindingsPopup due to missing line breaks.

Before
![image](https://github.com/veeso/termscp/assets/4526291/1aa431d2-24d5-463d-8830-3c5e2d73706f)

After
![image](https://github.com/veeso/termscp/assets/4526291/ecd1e131-3fba-4551-8833-48f0b0fee755)


## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [x] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
