### PR TITLE
added cfg smb-windows to be able to disable SMB on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -10,6 +10,7 @@ fn main() {
         windows: { target_family = "windows" },
         // exclusive features
         smb: { all(feature = "smb", not( macos )) },
-        smb_unix: { all(unix, feature = "smb", not(macos)) }
+        smb_unix: { all(unix, feature = "smb", not(macos)) },
+        smb_windows: { all(windows, feature = "smb") }
     }
 }

--- a/src/filetransfer/builder.rs
+++ b/src/filetransfer/builder.rs
@@ -140,7 +140,7 @@ impl Builder {
         }
     }
 
-    #[cfg(windows)]
+    #[cfg(smb_windows)]
     fn smb_client(params: SmbParams) -> SmbFs {
         let mut credentials = SmbCredentials::new(params.address, params.share);
 

--- a/src/ui/activities/setup/actions.rs
+++ b/src/ui/activities/setup/actions.rs
@@ -366,7 +366,7 @@ impl SetupActivity {
             .get_color(&Id::Theme(IdTheme::StatusSync))
             .map_err(|_| Id::Theme(IdTheme::StatusSync))?;
         // Update theme
-        let mut theme: &mut Theme = self.theme_mut();
+        let theme = self.theme_mut();
         theme.auth_address = auth_address;
         theme.auth_bookmarks = auth_bookmarks;
         theme.auth_password = auth_password;

--- a/src/utils/parser.rs
+++ b/src/utils/parser.rs
@@ -73,7 +73,7 @@ static REMOTE_SMB_OPT_REGEX: Lazy<Regex> = lazy_regex!(
  * - group 3: share
  * - group 4: remote-dir?
  */
-#[cfg(windows)]
+#[cfg(smb_windows)]
 static REMOTE_SMB_OPT_REGEX: Lazy<Regex> =
     lazy_regex!(r"(?:([^@]+)@)?(?:([^:\\]+))(?:\\([^\\]+))?(?:(\\.+))?");
 
@@ -171,7 +171,7 @@ fn parse_remote_opt_protocol(
             let protocol = match protocol {
                 Some(Ok(protocol)) => protocol,
                 Some(Err(err)) => return Err(err),
-                #[cfg(windows)]
+                #[cfg(smb_windows)]
                 None if groups.get(2).is_some() => FileTransferProtocol::Smb,
                 None => default,
             };
@@ -295,7 +295,7 @@ fn parse_smb_remote_opts(s: &str) -> Result<FileTransferParams, String> {
     }
 }
 
-#[cfg(windows)]
+#[cfg(smb_windows)]
 fn parse_smb_remote_opts(s: &str) -> Result<FileTransferParams, String> {
     match REMOTE_SMB_OPT_REGEX.captures(s) {
         Some(groups) => {
@@ -639,7 +639,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
+    #[cfg(smb_windows)]
     fn should_parse_smb_address() {
         let result = parse_remote_opt(&String::from("\\\\myserver\\myshare"))
             .ok()
@@ -652,7 +652,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg(windows)]
+    #[cfg(smb_windows)]
     fn should_parse_smb_address_with_opts() {
         let result = parse_remote_opt(&String::from("\\\\omar@myserver\\myshare\\path"))
             .ok()


### PR DESCRIPTION
# ISSUE 205 - SMB Isn't Scoped in the Code

Fixes #205

## Description

- Added `smb_windows` cfg build to disable smb on Windows if feature is disabled

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

