### PR TITLE
[BUG] - termscp not respecting port in ssh config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Released on 06/07/2023
 
 - [Issue 169](https://github.com/veeso/termscp/issues/169): Local working directory can now be specified in connection form and be saved into bookmarks.
 - [Issue 188](https://github.com/veeso/termscp/issues/188): The breadcrumbs path is not fallbacked after a failed enter into the directory
+- [Issue 215](https://github.com/veeso/termscp/issues/215): termscp not respecting port in SSH config. The port specified for the host in the SSH configuration wasn't evaluated.
 - SMB support is now a feature (you can build rust without default features to disable smb).
 - If SSH connection timeout is 0, the connection won't timeout.
 

--- a/src/config/serialization.rs
+++ b/src/config/serialization.rs
@@ -524,8 +524,10 @@ mod tests {
 
     #[test]
     fn test_config_serialization_theme_serialize() {
-        let mut theme: Theme = Theme::default();
-        theme.auth_address = Color::Rgb(240, 240, 240);
+        let mut theme: Theme = Theme {
+            auth_address: Color::Rgb(240, 240, 240),
+            ..Default::default()
+        };
         let tmpfile: tempfile::NamedTempFile = tempfile::NamedTempFile::new().unwrap();
         let (reader, writer) = create_file_ioers(tmpfile.path());
         assert!(serialize(&theme, Box::new(writer)).is_ok());

--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -315,8 +315,11 @@ mod tests {
 
     #[test]
     fn test_fs_explorer_stack() {
-        let mut explorer: FileExplorer = FileExplorer::default();
-        explorer.stack_size = 2;
+        let mut explorer = FileExplorer {
+            stack_size: 2,
+            dirstack: VecDeque::with_capacity(2),
+            ..Default::default()
+        };
         explorer.dirstack = VecDeque::with_capacity(2);
         // Push dir
         explorer.pushd(Path::new("/tmp"));

--- a/src/system/mod.rs
+++ b/src/system/mod.rs
@@ -7,7 +7,7 @@ pub mod auto_update;
 pub mod bookmarks_client;
 pub mod config_client;
 pub mod environment;
-pub(self) mod keys;
+mod keys;
 pub mod logging;
 pub mod notifications;
 pub mod sshkey_storage;

--- a/src/ui/activities/filetransfer/actions/mod.rs
+++ b/src/ui/activities/filetransfer/actions/mod.rs
@@ -3,11 +3,11 @@
 //! `filetransfer_activiy` is the module which implements the Filetransfer activity, which is the main activity afterall
 
 use remotefs::fs::UnixPex;
-pub(self) use remotefs::File;
+use remotefs::File;
 use tuirealm::{State, StateValue};
 
-pub(self) use super::browser::FileExplorerTab;
-pub(self) use super::{
+use super::browser::FileExplorerTab;
+use super::{
     FileTransferActivity, Id, LogLevel, Msg, PendingActionMsg, TransferMsg, TransferOpts,
     TransferPayload, UiMsg,
 };

--- a/src/ui/activities/filetransfer/mod.rs
+++ b/src/ui/activities/filetransfer/mod.rs
@@ -18,11 +18,11 @@ use std::time::Duration;
 
 // Includes
 use chrono::{DateTime, Local};
-pub(self) use lib::browser;
+use lib::browser;
 use lib::browser::Browser;
 use lib::transfer::{TransferOpts, TransferStates};
 use remotefs::RemoteFs;
-pub(self) use session::TransferPayload;
+use session::TransferPayload;
 use tempfile::TempDir;
 use tuirealm::{Application, EventListenerCfg, NoUserEvent};
 


### PR DESCRIPTION
# ISSUE 215 - [BUG] - termscp not respecting port in ssh config

Fixes #215

## Description

- Override connection params port if a port is specified for host in ssh config file

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the contribution guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I formatted the code with `cargo fmt`
- [ ] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have introduced no new *C-bindings*
- [ ] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
