### PR TITLE
fix: correct help text for update subcommand

### DIFF
--- a/src/cli_opts.rs
+++ b/src/cli_opts.rs
@@ -76,7 +76,7 @@ pub enum ArgsSubcommands {
 pub struct ConfigArgs {}
 
 #[derive(FromArgs)]
-/// import the specified theme
+/// update termscp to the latest version
 #[argh(subcommand, name = "update")]
 pub struct UpdateArgs {}
 


### PR DESCRIPTION
## Description

Fixes wrong help text for `update` subcommand introduced in 679a8297442f17d8adc9428aca304c8892d0eee9

## Type of change

Please select relevant options.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code follows the contribution guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [ ] I formatted the code with `cargo fmt`
- [ ] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have introduced no new *C-bindings*
- [ ] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit

## Acceptance tests

wait for a *project maintainer* to fulfill this section...

- [ ] regression test: ...
