### PR TITLE
fix: Jump to next entry after select

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Changelog
 
 - [Changelog](#changelog)
+  - [0.14.0](#0140)
   - [0.13.0](#0130)
   - [0.12.3](#0123)
   - [0.12.2](#0122)
@@ -34,6 +35,13 @@
   - [0.1.0](#010)
 
 ---
+
+## 0.14.0
+
+Released on ??
+
+- [Issue 241](https://github.com/veeso/termscp/issues/241): Jump to next entry after select
+- [Issue 257](https://github.com/veeso/termscp/issues/257): CLI remote args cannot handle '@' in the username
 
 ## 0.13.0
 

--- a/src/ui/activities/filetransfer/components/transfer/file_list.rs
+++ b/src/ui/activities/filetransfer/components/transfer/file_list.rs
@@ -102,6 +102,8 @@ impl OwnStates {
             true => self.deselect(entry),
             false => self.select(entry),
         }
+        // increment index
+        self.incr_list_index(false);
     }
 
     /// Select all files


### PR DESCRIPTION
# ISSUE 241 - Go to next line after selecting a file

Fixes #241

## Description

- increment index by one after selecting a file; no rewind

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
