### PR TITLE
fix: clippy error

### DIFF
--- a/src/ui/activities/filetransfer/mod.rs
+++ b/src/ui/activities/filetransfer/mod.rs
@@ -359,7 +359,6 @@ impl FileTransferActivity {
  * Keep it clean :)
  * Use methods instead!
  */
-
 impl Activity for FileTransferActivity {
     /// `on_create` is the function which must be called to initialize the activity.
     /// `on_create` must initialize all the data structures used by the activity


### PR DESCRIPTION
## Description

Fixed `empty-line-after-doc-comments` error added into the default warning in Clippy 1.83.

Failed workflow log:
https://github.com/veeso/termscp/actions/runs/12526546042/job/34939229766#step:7:332

```
error: empty line after doc comment
   --> src/ui/activities/filetransfer/mod.rs:357:1
    |
357 | / /**
358 | |  * Activity Trait
359 | |  * Keep it clean :)
360 | |  * Use methods instead!
361 | |  */
362 | |
    | |_
363 |   impl Activity for FileTransferActivity {
    |   -------------------------------------- the comment documents this implementation
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#empty_line_after_doc_comments
    = note: `-D clippy::empty-line-after-doc-comments` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::empty_line_after_doc_comments)]`
    = help: if the empty line is unintentional remove it

error: could not compile `termscp` (bin "termscp") due to 1 previous error
```

## Type of change

Please select relevant options.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Checklist

- [x] My code follows the contribution guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings
- [x] I formatted the code with `cargo fmt`
- [x] I checked my code using `cargo clippy` and reports no warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have introduced no new *C-bindings*
- [x] The changes I've made are Windows, MacOS, UNIX, Linux compatible (or I've handled them using `cfg target_os`)
- [ ] I increased or maintained the code coverage for the project, compared to the previous commit
