### PR TITLE
ci: Build artifacts for Windows x86_64 and Ubuntu x86_64

### DIFF
--- a/.github/workflows/build-artifacts.yml
+++ b/.github/workflows/build-artifacts.yml
@@ -140,5 +140,5 @@ jobs:
         with:
           if-no-files-found: error
           retention-days: 1
-          name: termscp-${{ matrix.platform.target }}.zip
+          name: termscp-${{ matrix.platform.target }}
           path: target/${{ matrix.platform.target }}/release/termscp.exe

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1272,7 +1272,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]


### PR DESCRIPTION
We can finally optimize the release process by building Windows and Ubuntu (x86_64) bins on github actions.