### PR TITLE
fix: replace panics reachable from user input with proper error handling

### DIFF
--- a/src/filetransfer/params.rs
+++ b/src/filetransfer/params.rs
@@ -25,10 +25,10 @@ pub enum HostBridgeParams {
 }
 
 impl HostBridgeParams {
-    pub fn unwrap_protocol_params(&self) -> &ProtocolParams {
+    pub fn protocol_params(&self) -> Option<&ProtocolParams> {
         match self {
-            HostBridgeParams::Localhost(_) => panic!("Localhost has no protocol params"),
-            HostBridgeParams::Remote(_, params) => params,
+            HostBridgeParams::Localhost(_) => None,
+            HostBridgeParams::Remote(_, params) => Some(params),
         }
     }
 
@@ -277,6 +277,19 @@ mod test {
     use pretty_assertions::assert_eq;
 
     use super::*;
+
+    #[test]
+    fn test_protocol_params_on_localhost_returns_none() {
+        let params = HostBridgeParams::Localhost(PathBuf::from("/tmp"));
+        assert!(params.protocol_params().is_none());
+    }
+
+    #[test]
+    fn test_protocol_params_on_remote_returns_some() {
+        let params =
+            HostBridgeParams::Remote(FileTransferProtocol::Sftp, ProtocolParams::default());
+        assert!(params.protocol_params().is_some());
+    }
 
     #[test]
     fn test_filetransfer_params() {

--- a/src/system/bookmarks_client.rs
+++ b/src/system/bookmarks_client.rs
@@ -190,8 +190,8 @@ impl BookmarksClient {
     ) {
         let name: String = name.as_ref().to_string();
         if name.is_empty() {
-            error!("Fatal error; bookmark name is empty");
-            panic!("Bookmark name can't be empty");
+            error!("Bookmark name is empty; ignoring add_bookmark request");
+            return;
         }
         // Make bookmark
         info!("Added bookmark {}", name);
@@ -557,15 +557,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
-
     fn test_system_bookmarks_bad_bookmark_name() {
         let tmp_dir: tempfile::TempDir = TempDir::new().ok().unwrap();
         let (cfg_path, key_path): (PathBuf, PathBuf) = get_paths(tmp_dir.path());
         // Initialize a new bookmarks client
         let mut client: BookmarksClient =
             BookmarksClient::new(cfg_path.as_path(), key_path.as_path(), 16, true).unwrap();
-        // Add bookmark
+        // Add bookmark with empty name should be silently ignored
         client.add_bookmark(
             "",
             make_generic_ftparams(
@@ -577,6 +575,8 @@ mod tests {
             ),
             true,
         );
+        // No bookmark should have been added
+        assert_eq!(client.iter_bookmarks().count(), 0);
     }
 
     #[test]
@@ -738,14 +738,13 @@ mod tests {
     }
 
     #[test]
-    #[should_panic]
     fn test_system_bookmarks_add_bookmark_empty() {
         let tmp_dir: tempfile::TempDir = TempDir::new().ok().unwrap();
         let (cfg_path, key_path): (PathBuf, PathBuf) = get_paths(tmp_dir.path());
         // Initialize a new bookmarks client
         let mut client: BookmarksClient =
             BookmarksClient::new(cfg_path.as_path(), key_path.as_path(), 16, true).unwrap();
-        // Add bookmark
+        // Add bookmark with empty name should be silently ignored
         client.add_bookmark(
             "",
             make_generic_ftparams(
@@ -757,6 +756,8 @@ mod tests {
             ),
             true,
         );
+        // No bookmark should have been added
+        assert_eq!(client.iter_bookmarks().count(), 0);
     }
 
     #[test]

--- a/src/system/keys/filestorage.rs
+++ b/src/system/keys/filestorage.rs
@@ -71,7 +71,10 @@ impl KeyStorage for FileStorage {
                     return Err(KeyStorageError::ProviderError);
                 }
                 // Set file to readonly
-                let mut permissions: Permissions = file.metadata().unwrap().permissions();
+                let mut permissions: Permissions = file
+                    .metadata()
+                    .map_err(|_| KeyStorageError::ProviderError)?
+                    .permissions();
                 permissions.set_readonly(true);
                 let _ = file.set_permissions(permissions);
                 Ok(())

--- a/src/ui/activities/filetransfer/mod.rs
+++ b/src/ui/activities/filetransfer/mod.rs
@@ -478,9 +478,10 @@ impl Activity for FileTransferActivity {
             && !self.browser.local_pane().fs.is_localhost()
         {
             let host_bridge_params = self.context().host_bridge_params().unwrap();
-            let ft_params = host_bridge_params.unwrap_protocol_params();
-            // print params
-            let msg: String = Self::get_connection_msg(ft_params);
+            let msg: String = match host_bridge_params.protocol_params() {
+                Some(ft_params) => Self::get_connection_msg(ft_params),
+                None => String::from("Connecting..."),
+            };
             // Set init state to connecting popup
             self.mount_blocking_wait(msg.as_str());
             // Connect to remote


### PR DESCRIPTION
## Summary
- Replace `.unwrap()` and `panic!()` calls that can be triggered by user input with proper error propagation
- Fix `exec()` in localhost to handle empty command strings
- Fix SMB client creation to return Result instead of panicking
- Fix tokio runtime creation to return Result instead of panicking
- Change `unwrap_protocol_params()` to return `Option` instead of panicking
- Fix `get_ssh_tokens()` to return `Option` instead of asserting
- Fix `add_bookmark()` to early-return instead of panicking on empty name
- Fix file metadata unwrap in key storage

## Test plan
- [x] Added test for exec with empty command
- [x] Added test for protocol_params on Localhost variant
- [x] Added test for get_ssh_tokens with invalid format
- [x] cargo build --no-default-features passes
- [x] cargo clippy --no-default-features -- -Dwarnings passes
- [x] cargo test --no-default-features --features github-actions --no-fail-fast passes