### PR TITLE
fix: replace assert! calls in UI activities with graceful error handling

### DIFF
--- a/src/ui/activities/auth/update.rs
+++ b/src/ui/activities/auth/update.rs
@@ -96,7 +96,9 @@ impl AuthActivity {
                     },
                 };
 
-                assert!(self.app.active(focus).is_ok());
+                if let Err(err) = self.app.active(focus) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             FormMsg::LoadRecent(i) => {
                 self.load_recent(self.last_form_tab, i);
@@ -120,7 +122,9 @@ impl AuthActivity {
                     },
                 };
 
-                assert!(self.app.active(focus).is_ok());
+                if let Err(err) = self.app.active(focus) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             FormMsg::HostBridgeProtocolChanged(protocol) => {
                 self.host_bridge_protocol = protocol;
@@ -173,7 +177,9 @@ impl AuthActivity {
                 } else {
                     &Id::HostBridge(AuthFormId::Port)
                 };
-                assert!(self.app.active(id).is_ok());
+                if let Err(err) = self.app.active(id) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::AddressBlurDown) => {
                 let id = if cfg!(windows) && self.remote_input_mask() == InputMask::Smb {
@@ -181,48 +187,56 @@ impl AuthActivity {
                 } else {
                     &Id::Remote(AuthFormId::Port)
                 };
-                assert!(self.app.active(id).is_ok());
+                if let Err(err) = self.app.active(id) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::AddressBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Protocol))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::AddressBlurUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Protocol)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::BookmarksListBlur => {
-                assert!(self.app.active(&Id::RecentsList).is_ok());
+                if let Err(err) = self.app.active(&Id::RecentsList) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::BookmarkNameBlur => {
-                assert!(self.app.active(&Id::BookmarkSavePassword).is_ok());
+                if let Err(err) = self.app.active(&Id::BookmarkSavePassword) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::BookmarksTabBlur => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Protocol))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::ChangeFormTab) => {
                 self.last_form_tab = FormTab::Remote;
-                assert!(self.app.active(&Id::Remote(AuthFormId::Protocol)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::ChangeFormTab) => {
                 self.last_form_tab = FormTab::HostBridge;
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Protocol))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::CloseDeleteBookmark => {
-                assert!(self.app.umount(&Id::DeleteBookmarkPopup).is_ok());
+                if let Err(err) = self.app.umount(&Id::DeleteBookmarkPopup) {
+                    error!("Failed to umount component: {err}");
+                }
             }
             UiMsg::CloseDeleteRecent => {
-                assert!(self.app.umount(&Id::DeleteRecentPopup).is_ok());
+                if let Err(err) = self.app.umount(&Id::DeleteRecentPopup) {
+                    error!("Failed to umount component: {err}");
+                }
             }
             UiMsg::CloseErrorPopup => {
                 self.umount_error();
@@ -231,596 +245,522 @@ impl AuthActivity {
                 self.umount_info();
             }
             UiMsg::CloseInstallUpdatePopup => {
-                assert!(self.app.umount(&Id::NewVersionChangelog).is_ok());
-                assert!(self.app.umount(&Id::InstallUpdatePopup).is_ok());
+                if let Err(err) = self.app.umount(&Id::NewVersionChangelog) {
+                    error!("Failed to umount component: {err}");
+                }
+                if let Err(err) = self.app.umount(&Id::InstallUpdatePopup) {
+                    error!("Failed to umount component: {err}");
+                }
             }
             UiMsg::CloseKeybindingsPopup => {
                 self.umount_help();
             }
             UiMsg::CloseQuitPopup => self.umount_quit(),
             UiMsg::CloseSaveBookmark => {
-                assert!(self.app.umount(&Id::BookmarkName).is_ok());
-                assert!(self.app.umount(&Id::BookmarkSavePassword).is_ok());
+                if let Err(err) = self.app.umount(&Id::BookmarkName) {
+                    error!("Failed to umount component: {err}");
+                }
+                if let Err(err) = self.app.umount(&Id::BookmarkSavePassword) {
+                    error!("Failed to umount component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::LocalDirectoryBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Protocol))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::LocalDirectoryBlurDown) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Protocol)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::LocalDirectoryBlurUp) => {
-                assert!(
-                    self.app
-                        .active(match self.host_bridge_input_mask() {
-                            InputMask::Localhost => &Id::HostBridge(AuthFormId::Protocol),
-                            _ => &Id::HostBridge(AuthFormId::RemoteDirectory),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.host_bridge_input_mask() {
+                    InputMask::Localhost => &Id::HostBridge(AuthFormId::Protocol),
+                    _ => &Id::HostBridge(AuthFormId::RemoteDirectory),
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::LocalDirectoryBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::RemoteDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::RemoteDirectory)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::ParamsFormBlur) => {
-                assert!(self.app.active(&Id::BookmarksList).is_ok());
+                if let Err(err) = self.app.active(&Id::BookmarksList) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::ParamsFormBlur) => {
-                assert!(self.app.active(&Id::BookmarksList).is_ok());
+                if let Err(err) = self.app.active(&Id::BookmarksList) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::PasswordBlurDown) => {
-                assert!(
-                    self.app
-                        .active(match self.host_bridge_input_mask() {
-                            InputMask::Localhost => unreachable!(),
-                            InputMask::Generic => &Id::HostBridge(AuthFormId::RemoteDirectory),
-                            #[cfg(posix)]
-                            InputMask::Smb => &Id::HostBridge(AuthFormId::SmbWorkgroup),
-                            #[cfg(win)]
-                            InputMask::Smb => &Id::HostBridge(AuthFormId::RemoteDirectory),
-                            InputMask::AwsS3 =>
-                                unreachable!("this shouldn't happen (password on s3)"),
-                            InputMask::Kube =>
-                                unreachable!("this shouldn't happen (password on kube)"),
-                            InputMask::WebDAV => &Id::HostBridge(AuthFormId::RemoteDirectory),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.host_bridge_input_mask() {
+                    InputMask::Localhost => unreachable!(),
+                    InputMask::Generic => &Id::HostBridge(AuthFormId::RemoteDirectory),
+                    #[cfg(posix)]
+                    InputMask::Smb => &Id::HostBridge(AuthFormId::SmbWorkgroup),
+                    #[cfg(win)]
+                    InputMask::Smb => &Id::HostBridge(AuthFormId::RemoteDirectory),
+                    InputMask::AwsS3 => unreachable!("this shouldn't happen (password on s3)"),
+                    InputMask::Kube => unreachable!("this shouldn't happen (password on kube)"),
+                    InputMask::WebDAV => &Id::HostBridge(AuthFormId::RemoteDirectory),
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::PasswordBlurDown) => {
-                assert!(
-                    self.app
-                        .active(match self.remote_input_mask() {
-                            InputMask::Localhost => unreachable!(),
-                            InputMask::Generic => &Id::Remote(AuthFormId::RemoteDirectory),
-                            #[cfg(posix)]
-                            InputMask::Smb => &Id::Remote(AuthFormId::SmbWorkgroup),
-                            #[cfg(win)]
-                            InputMask::Smb => &Id::Remote(AuthFormId::RemoteDirectory),
-                            InputMask::AwsS3 =>
-                                unreachable!("this shouldn't happen (password on s3)"),
-                            InputMask::Kube =>
-                                unreachable!("this shouldn't happen (password on kube)"),
-                            InputMask::WebDAV => &Id::Remote(AuthFormId::RemoteDirectory),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.remote_input_mask() {
+                    InputMask::Localhost => unreachable!(),
+                    InputMask::Generic => &Id::Remote(AuthFormId::RemoteDirectory),
+                    #[cfg(posix)]
+                    InputMask::Smb => &Id::Remote(AuthFormId::SmbWorkgroup),
+                    #[cfg(win)]
+                    InputMask::Smb => &Id::Remote(AuthFormId::RemoteDirectory),
+                    InputMask::AwsS3 => unreachable!("this shouldn't happen (password on s3)"),
+                    InputMask::Kube => unreachable!("this shouldn't happen (password on kube)"),
+                    InputMask::WebDAV => &Id::Remote(AuthFormId::RemoteDirectory),
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::PasswordBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Username))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Username)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::PasswordBlurUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Username)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Username)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::PortBlurDown) => {
-                assert!(
-                    self.app
-                        .active(match self.host_bridge_input_mask() {
-                            InputMask::Generic => &Id::HostBridge(AuthFormId::Username),
-                            InputMask::Smb => &Id::HostBridge(AuthFormId::SmbShare),
-                            InputMask::Localhost
-                            | InputMask::AwsS3
-                            | InputMask::Kube
-                            | InputMask::WebDAV =>
-                                unreachable!("this shouldn't happen (port on s3/kube/webdav)"),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.host_bridge_input_mask() {
+                    InputMask::Generic => &Id::HostBridge(AuthFormId::Username),
+                    InputMask::Smb => &Id::HostBridge(AuthFormId::SmbShare),
+                    InputMask::Localhost
+                    | InputMask::AwsS3
+                    | InputMask::Kube
+                    | InputMask::WebDAV => {
+                        unreachable!("this shouldn't happen (port on s3/kube/webdav)")
+                    }
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::PortBlurDown) => {
-                assert!(
-                    self.app
-                        .active(match self.remote_input_mask() {
-                            InputMask::Generic => &Id::Remote(AuthFormId::Username),
-                            InputMask::Smb => &Id::Remote(AuthFormId::SmbShare),
-                            InputMask::Localhost
-                            | InputMask::AwsS3
-                            | InputMask::Kube
-                            | InputMask::WebDAV =>
-                                unreachable!("this shouldn't happen (port on s3/kube/webdav)"),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.remote_input_mask() {
+                    InputMask::Generic => &Id::Remote(AuthFormId::Username),
+                    InputMask::Smb => &Id::Remote(AuthFormId::SmbShare),
+                    InputMask::Localhost
+                    | InputMask::AwsS3
+                    | InputMask::Kube
+                    | InputMask::WebDAV => {
+                        unreachable!("this shouldn't happen (port on s3/kube/webdav)")
+                    }
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::PortBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Address))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Address)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::PortBlurUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Address)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Address)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::ProtocolBlurDown) => {
-                assert!(
-                    self.app
-                        .active(match self.host_bridge_input_mask() {
-                            InputMask::Localhost => &Id::HostBridge(AuthFormId::LocalDirectory),
-                            InputMask::Generic => &Id::HostBridge(AuthFormId::Address),
-                            InputMask::Smb => &Id::HostBridge(AuthFormId::Address),
-                            InputMask::AwsS3 => &Id::HostBridge(AuthFormId::S3Bucket),
-                            InputMask::Kube => &Id::HostBridge(AuthFormId::KubeNamespace),
-                            InputMask::WebDAV => &Id::HostBridge(AuthFormId::WebDAVUri),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.host_bridge_input_mask() {
+                    InputMask::Localhost => &Id::HostBridge(AuthFormId::LocalDirectory),
+                    InputMask::Generic => &Id::HostBridge(AuthFormId::Address),
+                    InputMask::Smb => &Id::HostBridge(AuthFormId::Address),
+                    InputMask::AwsS3 => &Id::HostBridge(AuthFormId::S3Bucket),
+                    InputMask::Kube => &Id::HostBridge(AuthFormId::KubeNamespace),
+                    InputMask::WebDAV => &Id::HostBridge(AuthFormId::WebDAVUri),
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::ProtocolBlurDown) => {
-                assert!(
-                    self.app
-                        .active(match self.remote_input_mask() {
-                            InputMask::Localhost => &Id::Remote(AuthFormId::LocalDirectory),
-                            InputMask::Generic => &Id::Remote(AuthFormId::Address),
-                            InputMask::Smb => &Id::Remote(AuthFormId::Address),
-                            InputMask::AwsS3 => &Id::Remote(AuthFormId::S3Bucket),
-                            InputMask::Kube => &Id::Remote(AuthFormId::KubeNamespace),
-                            InputMask::WebDAV => &Id::Remote(AuthFormId::WebDAVUri),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.remote_input_mask() {
+                    InputMask::Localhost => &Id::Remote(AuthFormId::LocalDirectory),
+                    InputMask::Generic => &Id::Remote(AuthFormId::Address),
+                    InputMask::Smb => &Id::Remote(AuthFormId::Address),
+                    InputMask::AwsS3 => &Id::Remote(AuthFormId::S3Bucket),
+                    InputMask::Kube => &Id::Remote(AuthFormId::KubeNamespace),
+                    InputMask::WebDAV => &Id::Remote(AuthFormId::WebDAVUri),
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::ProtocolBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::LocalDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::LocalDirectory)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::ProtocolBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::LocalDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::LocalDirectory)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::RececentsListBlur => {
-                assert!(self.app.active(&Id::BookmarksList).is_ok());
+                if let Err(err) = self.app.active(&Id::BookmarksList) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::RemoteDirectoryBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::LocalDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::LocalDirectory)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::RemoteDirectoryBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::LocalDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::LocalDirectory)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::RemoteDirectoryBlurUp) => {
-                assert!(
-                    self.app
-                        .active(match self.host_bridge_input_mask() {
-                            InputMask::Localhost => unreachable!(),
-                            InputMask::Generic => &Id::HostBridge(AuthFormId::Password),
-                            #[cfg(posix)]
-                            InputMask::Smb => &Id::HostBridge(AuthFormId::SmbWorkgroup),
-                            #[cfg(win)]
-                            InputMask::Smb => &Id::HostBridge(AuthFormId::Password),
-                            InputMask::Kube => &Id::HostBridge(AuthFormId::KubeClientKey),
-                            InputMask::AwsS3 => &Id::HostBridge(AuthFormId::S3NewPathStyle),
-                            InputMask::WebDAV => &Id::HostBridge(AuthFormId::Password),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.host_bridge_input_mask() {
+                    InputMask::Localhost => unreachable!(),
+                    InputMask::Generic => &Id::HostBridge(AuthFormId::Password),
+                    #[cfg(posix)]
+                    InputMask::Smb => &Id::HostBridge(AuthFormId::SmbWorkgroup),
+                    #[cfg(win)]
+                    InputMask::Smb => &Id::HostBridge(AuthFormId::Password),
+                    InputMask::Kube => &Id::HostBridge(AuthFormId::KubeClientKey),
+                    InputMask::AwsS3 => &Id::HostBridge(AuthFormId::S3NewPathStyle),
+                    InputMask::WebDAV => &Id::HostBridge(AuthFormId::Password),
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::RemoteDirectoryBlurUp) => {
-                assert!(
-                    self.app
-                        .active(match self.remote_input_mask() {
-                            InputMask::Localhost => unreachable!(),
-                            InputMask::Generic => &Id::Remote(AuthFormId::Password),
-                            #[cfg(posix)]
-                            InputMask::Smb => &Id::Remote(AuthFormId::SmbWorkgroup),
-                            #[cfg(win)]
-                            InputMask::Smb => &Id::Remote(AuthFormId::Password),
-                            InputMask::Kube => &Id::Remote(AuthFormId::KubeClientKey),
-                            InputMask::AwsS3 => &Id::Remote(AuthFormId::S3NewPathStyle),
-                            InputMask::WebDAV => &Id::Remote(AuthFormId::Password),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.remote_input_mask() {
+                    InputMask::Localhost => unreachable!(),
+                    InputMask::Generic => &Id::Remote(AuthFormId::Password),
+                    #[cfg(posix)]
+                    InputMask::Smb => &Id::Remote(AuthFormId::SmbWorkgroup),
+                    #[cfg(win)]
+                    InputMask::Smb => &Id::Remote(AuthFormId::Password),
+                    InputMask::Kube => &Id::Remote(AuthFormId::KubeClientKey),
+                    InputMask::AwsS3 => &Id::Remote(AuthFormId::S3NewPathStyle),
+                    InputMask::WebDAV => &Id::Remote(AuthFormId::Password),
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3BucketBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3Region))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3Region)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3BucketBlurDown) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::S3Region)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3Region)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3BucketBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Protocol))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3BucketBlurUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Protocol)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3RegionBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3Endpoint))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3Endpoint)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3RegionBlurDown) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::S3Endpoint)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3Endpoint)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3RegionBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3Bucket))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3Bucket)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3RegionBlurUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::S3Bucket)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3Bucket)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3EndpointBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3Profile))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3Profile)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3EndpointBlurDown) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::S3Profile)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3Profile)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3EndpointBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3Region))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3Region)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3EndpointBlurUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::S3Region)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3Region)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3ProfileBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3AccessKey))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3AccessKey)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3ProfileBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::S3AccessKey))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3AccessKey)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3ProfileBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3Endpoint))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3Endpoint)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3ProfileBlurUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::S3Endpoint)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3Endpoint)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3AccessKeyBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3SecretAccessKey))
-                        .is_ok()
-                );
+                if let Err(err) = self
+                    .app
+                    .active(&Id::HostBridge(AuthFormId::S3SecretAccessKey))
+                {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3AccessKeyBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::S3SecretAccessKey))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3SecretAccessKey)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3AccessKeyBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3Profile))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3Profile)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3AccessKeyBlurUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::S3Profile)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3Profile)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3SecretAccessKeyBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3SecurityToken))
-                        .is_ok()
-                );
+                if let Err(err) = self
+                    .app
+                    .active(&Id::HostBridge(AuthFormId::S3SecurityToken))
+                {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3SecretAccessKeyBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::S3SecurityToken))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3SecurityToken)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3SecretAccessKeyBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3AccessKey))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3AccessKey)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3SecretAccessKeyBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::S3AccessKey))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3AccessKey)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3SecurityTokenBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3SessionToken))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3SessionToken)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3SecurityTokenBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::S3SessionToken))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3SessionToken)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3SecurityTokenBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3SecretAccessKey))
-                        .is_ok()
-                );
+                if let Err(err) = self
+                    .app
+                    .active(&Id::HostBridge(AuthFormId::S3SecretAccessKey))
+                {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3SecurityTokenBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::S3SecretAccessKey))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3SecretAccessKey)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3SessionTokenBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3NewPathStyle))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3NewPathStyle)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3SessionTokenBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::S3NewPathStyle))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3NewPathStyle)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3SessionTokenBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3SecurityToken))
-                        .is_ok()
-                );
+                if let Err(err) = self
+                    .app
+                    .active(&Id::HostBridge(AuthFormId::S3SecurityToken))
+                {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3SessionTokenBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::S3SecurityToken))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3SecurityToken)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3NewPathStyleBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::RemoteDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self
+                    .app
+                    .active(&Id::HostBridge(AuthFormId::RemoteDirectory))
+                {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3NewPathStyleBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::RemoteDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::RemoteDirectory)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::S3NewPathStyleBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::S3SessionToken))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::S3SessionToken)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::S3NewPathStyleBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::S3SessionToken))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::S3SessionToken)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::KubeClientCertBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::KubeClientKey))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::KubeClientKey)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::KubeClientCertBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::KubeClientKey))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::KubeClientKey)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::KubeClientCertBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::KubeUsername))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::KubeUsername)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::KubeClientCertBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::KubeUsername))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::KubeUsername)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::KubeClientKeyBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::RemoteDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self
+                    .app
+                    .active(&Id::HostBridge(AuthFormId::RemoteDirectory))
+                {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::KubeClientKeyBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::RemoteDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::RemoteDirectory)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::KubeClientKeyBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::KubeClientCert))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::KubeClientCert)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::KubeClientKeyBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::KubeClientCert))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::KubeClientCert)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::KubeNamespaceBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::KubeClusterUrl))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::KubeClusterUrl)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::KubeNamespaceBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::KubeClusterUrl))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::KubeClusterUrl)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::KubeNamespaceBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Protocol))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::KubeNamespaceBlurUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Protocol)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::KubeClusterUrlBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::KubeUsername))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::KubeUsername)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::KubeClusterUrlBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::KubeUsername))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::KubeUsername)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::KubeClusterUrlBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::KubeNamespace))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::KubeNamespace)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::KubeClusterUrlBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::KubeNamespace))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::KubeNamespace)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::KubeUsernameBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::KubeClientCert))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::KubeClientCert)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::KubeUsernameBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::KubeClientCert))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::KubeClientCert)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::KubeUsernameBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::KubeClusterUrl))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::KubeClusterUrl)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::KubeUsernameBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::KubeClusterUrl))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::KubeClusterUrl)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::SmbShareBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Username))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Username)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::SmbShareBlurDown) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Username)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Username)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::SmbShareBlurUp) => {
                 let id = if cfg!(windows) && self.host_bridge_input_mask() == InputMask::Smb {
@@ -828,7 +768,9 @@ impl AuthActivity {
                 } else {
                     &Id::HostBridge(AuthFormId::Port)
                 };
-                assert!(self.app.active(id).is_ok());
+                if let Err(err) = self.app.active(id) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::SmbShareBlurUp) => {
                 let id = if cfg!(windows) && self.remote_input_mask() == InputMask::Smb {
@@ -836,38 +778,41 @@ impl AuthActivity {
                 } else {
                     &Id::Remote(AuthFormId::Port)
                 };
-                assert!(self.app.active(id).is_ok());
+                if let Err(err) = self.app.active(id) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             #[cfg(posix)]
             UiMsg::HostBridge(UiAuthFormMsg::SmbWorkgroupDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::RemoteDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self
+                    .app
+                    .active(&Id::HostBridge(AuthFormId::RemoteDirectory))
+                {
+                    error!("Failed to activate component: {err}");
+                }
             }
             #[cfg(posix)]
             UiMsg::Remote(UiAuthFormMsg::SmbWorkgroupDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::Remote(AuthFormId::RemoteDirectory))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::RemoteDirectory)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             #[cfg(posix)]
             UiMsg::HostBridge(UiAuthFormMsg::SmbWorkgroupUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Password))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Password)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             #[cfg(posix)]
             UiMsg::Remote(UiAuthFormMsg::SmbWorkgroupUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Password)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Password)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::SaveBookmarkPasswordBlur => {
-                assert!(self.app.active(&Id::BookmarkName).is_ok());
+                if let Err(err) = self.app.active(&Id::BookmarkName) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::ShowDeleteBookmarkPopup => {
                 self.mount_bookmark_del_dialog();
@@ -888,66 +833,58 @@ impl AuthActivity {
                 self.mount_bookmark_save_dialog(self.get_current_form_tab());
             }
             UiMsg::HostBridge(UiAuthFormMsg::UsernameBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Password))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Password)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::UsernameBlurDown) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Password)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Password)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::UsernameBlurUp) => {
-                assert!(
-                    self.app
-                        .active(match self.host_bridge_input_mask() {
-                            InputMask::Localhost => unreachable!(),
-                            InputMask::Generic => &Id::HostBridge(AuthFormId::Port),
-                            InputMask::Smb => &Id::HostBridge(AuthFormId::SmbShare),
-                            InputMask::Kube =>
-                                unreachable!("this shouldn't happen (username on kube)"),
-                            InputMask::AwsS3 =>
-                                unreachable!("this shouldn't happen (username on s3)"),
-                            InputMask::WebDAV => &Id::HostBridge(AuthFormId::WebDAVUri),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.host_bridge_input_mask() {
+                    InputMask::Localhost => unreachable!(),
+                    InputMask::Generic => &Id::HostBridge(AuthFormId::Port),
+                    InputMask::Smb => &Id::HostBridge(AuthFormId::SmbShare),
+                    InputMask::Kube => unreachable!("this shouldn't happen (username on kube)"),
+                    InputMask::AwsS3 => unreachable!("this shouldn't happen (username on s3)"),
+                    InputMask::WebDAV => &Id::HostBridge(AuthFormId::WebDAVUri),
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::UsernameBlurUp) => {
-                assert!(
-                    self.app
-                        .active(match self.remote_input_mask() {
-                            InputMask::Localhost => unreachable!(),
-                            InputMask::Generic => &Id::Remote(AuthFormId::Port),
-                            InputMask::Smb => &Id::Remote(AuthFormId::SmbShare),
-                            InputMask::Kube =>
-                                unreachable!("this shouldn't happen (username on kube)"),
-                            InputMask::AwsS3 =>
-                                unreachable!("this shouldn't happen (username on s3)"),
-                            InputMask::WebDAV => &Id::Remote(AuthFormId::WebDAVUri),
-                        })
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(match self.remote_input_mask() {
+                    InputMask::Localhost => unreachable!(),
+                    InputMask::Generic => &Id::Remote(AuthFormId::Port),
+                    InputMask::Smb => &Id::Remote(AuthFormId::SmbShare),
+                    InputMask::Kube => unreachable!("this shouldn't happen (username on kube)"),
+                    InputMask::AwsS3 => unreachable!("this shouldn't happen (username on s3)"),
+                    InputMask::WebDAV => &Id::Remote(AuthFormId::WebDAVUri),
+                }) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::WebDAVUriBlurDown) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Username))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Username)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::WebDAVUriBlurDown) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Username)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Username)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::HostBridge(UiAuthFormMsg::WebDAVUriBlurUp) => {
-                assert!(
-                    self.app
-                        .active(&Id::HostBridge(AuthFormId::Protocol))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::HostBridge(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::Remote(UiAuthFormMsg::WebDAVUriBlurUp) => {
-                assert!(self.app.active(&Id::Remote(AuthFormId::Protocol)).is_ok());
+                if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Protocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             UiMsg::WindowResized => {
                 self.redraw = true;

--- a/src/ui/activities/auth/view.rs
+++ b/src/ui/activities/auth/view.rs
@@ -28,26 +28,26 @@ impl AuthActivity {
         let key_color = self.theme().misc_keys;
         let info_color = self.theme().misc_info_dialog;
         // Headers
-        assert!(
-            self.app
-                .mount(Id::Title, Box::<components::Title>::default(), vec![])
-                .is_ok()
-        );
-        assert!(
+        if let Err(err) = self
+            .app
+            .mount(Id::Title, Box::<components::Title>::default(), vec![])
+        {
+            error!("Failed to mount component: {err}");
+        }
+        if let Err(err) =
             self.app
                 .mount(Id::Subtitle, Box::<components::Subtitle>::default(), vec![])
-                .is_ok()
-        );
+        {
+            error!("Failed to mount component: {err}");
+        }
         // Footer
-        assert!(
-            self.app
-                .mount(
-                    Id::HelpFooter,
-                    Box::new(components::HelpFooter::new(key_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.mount(
+            Id::HelpFooter,
+            Box::new(components::HelpFooter::new(key_color)),
+            vec![],
+        ) {
+            error!("Failed to mount component: {err}");
+        }
 
         // Host bridge auth form
         self.mount_host_bridge_protocol(HostBridgeProtocol::Localhost);
@@ -116,18 +116,16 @@ impl AuthActivity {
             .get_string(super::STORE_KEY_LATEST_VERSION)
         {
             let version: String = version.to_string();
-            assert!(
-                self.app
-                    .mount(
-                        Id::NewVersionDisclaimer,
-                        Box::new(components::NewVersionDisclaimer::new(
-                            version.as_str(),
-                            info_color
-                        )),
-                        vec![]
-                    )
-                    .is_ok()
-            );
+            if let Err(err) = self.app.mount(
+                Id::NewVersionDisclaimer,
+                Box::new(components::NewVersionDisclaimer::new(
+                    version.as_str(),
+                    info_color,
+                )),
+                vec![],
+            ) {
+                error!("Failed to mount component: {err}");
+            }
         }
         // Load bookmarks
         self.view_bookmarks();
@@ -135,7 +133,9 @@ impl AuthActivity {
         // Global listener
         self.init_global_listener();
         // Active protocol
-        assert!(self.app.active(&Id::Remote(AuthFormId::Protocol)).is_ok());
+        if let Err(err) = self.app.active(&Id::Remote(AuthFormId::Protocol)) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Display view on canvas
@@ -459,15 +459,13 @@ impl AuthActivity {
             })
             .collect();
         let bookmarks_color = self.theme().auth_bookmarks;
-        assert!(
-            self.app
-                .remount(
-                    Id::BookmarksList,
-                    Box::new(components::BookmarksList::new(&bookmarks, bookmarks_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::BookmarksList,
+            Box::new(components::BookmarksList::new(&bookmarks, bookmarks_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     /// View recent connections
@@ -478,15 +476,13 @@ impl AuthActivity {
             .map(|x| Self::fmt_recent(self.bookmarks_client().unwrap().get_recent(x).unwrap()))
             .collect();
         let recents_color = self.theme().auth_recents;
-        assert!(
-            self.app
-                .remount(
-                    Id::RecentsList,
-                    Box::new(components::RecentsList::new(&bookmarks, recents_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::RecentsList,
+            Box::new(components::RecentsList::new(&bookmarks, recents_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     // -- mount
@@ -494,16 +490,16 @@ impl AuthActivity {
     /// Mount error box
     pub(super) fn mount_error<S: AsRef<str>>(&mut self, text: S) {
         let err_color = self.theme().misc_error_dialog;
-        assert!(
-            self.app
-                .remount(
-                    Id::ErrorPopup,
-                    Box::new(components::ErrorPopup::new(text, err_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::ErrorPopup).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::ErrorPopup,
+            Box::new(components::ErrorPopup::new(text, err_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::ErrorPopup) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount error message
@@ -514,16 +510,16 @@ impl AuthActivity {
     /// Mount info box
     pub(super) fn mount_info<S: AsRef<str>>(&mut self, text: S) {
         let color = self.theme().misc_info_dialog;
-        assert!(
-            self.app
-                .remount(
-                    Id::InfoPopup,
-                    Box::new(components::InfoPopup::new(text, color)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::InfoPopup).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::InfoPopup,
+            Box::new(components::InfoPopup::new(text, color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::InfoPopup) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount info message
@@ -534,16 +530,16 @@ impl AuthActivity {
     /// Mount wait box
     pub(super) fn mount_wait(&mut self, text: &str) {
         let wait_color = self.theme().misc_info_dialog;
-        assert!(
-            self.app
-                .remount(
-                    Id::WaitPopup,
-                    Box::new(components::WaitPopup::new(text, wait_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::WaitPopup).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::WaitPopup,
+            Box::new(components::WaitPopup::new(text, wait_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::WaitPopup) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount wait message
@@ -554,16 +550,16 @@ impl AuthActivity {
     /// Mount size error
     pub(super) fn mount_size_err(&mut self) {
         // Mount
-        assert!(
-            self.app
-                .remount(
-                    Id::WindowSizeError,
-                    Box::new(components::WindowSizeError::new(Color::Red)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::WindowSizeError).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::WindowSizeError,
+            Box::new(components::WindowSizeError::new(Color::Red)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::WindowSizeError) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount error size error
@@ -575,16 +571,16 @@ impl AuthActivity {
     pub(super) fn mount_quit(&mut self) {
         // Protocol
         let quit_color = self.theme().misc_quit_dialog;
-        assert!(
-            self.app
-                .remount(
-                    Id::QuitPopup,
-                    Box::new(components::QuitPopup::new(quit_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::QuitPopup).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::QuitPopup,
+            Box::new(components::QuitPopup::new(quit_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::QuitPopup) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount quit popup
@@ -595,16 +591,16 @@ impl AuthActivity {
     /// Mount bookmark delete dialog
     pub(super) fn mount_bookmark_del_dialog(&mut self) {
         let warn_color = self.theme().misc_warn_dialog;
-        assert!(
-            self.app
-                .remount(
-                    Id::DeleteBookmarkPopup,
-                    Box::new(components::DeleteBookmarkPopup::new(warn_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::DeleteBookmarkPopup).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::DeleteBookmarkPopup,
+            Box::new(components::DeleteBookmarkPopup::new(warn_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::DeleteBookmarkPopup) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// umount delete bookmark dialog
@@ -615,16 +611,16 @@ impl AuthActivity {
     /// Mount recent delete dialog
     pub(super) fn mount_recent_del_dialog(&mut self) {
         let warn_color = self.theme().misc_warn_dialog;
-        assert!(
-            self.app
-                .remount(
-                    Id::DeleteRecentPopup,
-                    Box::new(components::DeleteRecentPopup::new(warn_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::DeleteRecentPopup).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::DeleteRecentPopup,
+            Box::new(components::DeleteRecentPopup::new(warn_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::DeleteRecentPopup) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// umount delete recent dialog
@@ -636,26 +632,24 @@ impl AuthActivity {
     pub(super) fn mount_bookmark_save_dialog(&mut self, form_tab: FormTab) {
         let save_color = self.theme().misc_save_dialog;
         let warn_color = self.theme().misc_warn_dialog;
-        assert!(
-            self.app
-                .remount(
-                    Id::BookmarkName,
-                    Box::new(components::BookmarkName::new(form_tab, save_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::BookmarkSavePassword,
-                    Box::new(components::BookmarkSavePassword::new(form_tab, warn_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::BookmarkName,
+            Box::new(components::BookmarkName::new(form_tab, save_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::BookmarkSavePassword,
+            Box::new(components::BookmarkSavePassword::new(form_tab, warn_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Give focus to input bookmark name
-        assert!(self.app.active(&Id::BookmarkName).is_ok());
+        if let Err(err) = self.app.active(&Id::BookmarkName) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount bookmark save dialog
@@ -667,17 +661,17 @@ impl AuthActivity {
     /// Mount keybindings
     pub(super) fn mount_keybindings(&mut self) {
         let key_color = self.theme().misc_keys;
-        assert!(
-            self.app
-                .remount(
-                    Id::Keybindings,
-                    Box::new(components::Keybindings::new(key_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Keybindings,
+            Box::new(components::Keybindings::new(key_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Active help
-        assert!(self.app.active(&Id::Keybindings).is_ok());
+        if let Err(err) = self.app.active(&Id::Keybindings) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount help
@@ -692,25 +686,23 @@ impl AuthActivity {
         {
             // make spans
             let info_color = self.theme().misc_info_dialog;
-            assert!(
-                self.app
-                    .remount(
-                        Id::NewVersionChangelog,
-                        Box::new(components::ReleaseNotes::new(release_notes, info_color)),
-                        vec![]
-                    )
-                    .is_ok()
-            );
-            assert!(
-                self.app
-                    .remount(
-                        Id::InstallUpdatePopup,
-                        Box::new(components::InstallUpdatePopup::new(info_color)),
-                        vec![]
-                    )
-                    .is_ok()
-            );
-            assert!(self.app.active(&Id::InstallUpdatePopup).is_ok());
+            if let Err(err) = self.app.remount(
+                Id::NewVersionChangelog,
+                Box::new(components::ReleaseNotes::new(release_notes, info_color)),
+                vec![],
+            ) {
+                error!("Failed to remount component: {err}");
+            }
+            if let Err(err) = self.app.remount(
+                Id::InstallUpdatePopup,
+                Box::new(components::InstallUpdatePopup::new(info_color)),
+                vec![],
+            ) {
+                error!("Failed to remount component: {err}");
+            }
+            if let Err(err) = self.app.active(&Id::InstallUpdatePopup) {
+                error!("Failed to activate component: {err}");
+            }
         }
     }
 
@@ -722,34 +714,30 @@ impl AuthActivity {
 
     pub(super) fn mount_host_bridge_protocol(&mut self, protocol: HostBridgeProtocol) {
         let protocol_color = self.theme().auth_protocol;
-        assert!(
-            self.app
-                .remount(
-                    Id::HostBridge(AuthFormId::Protocol),
-                    Box::new(components::HostBridgeProtocolRadio::new(
-                        protocol,
-                        protocol_color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::HostBridge(AuthFormId::Protocol),
+            Box::new(components::HostBridgeProtocolRadio::new(
+                protocol,
+                protocol_color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_remote_protocol(&mut self, protocol: FileTransferProtocol) {
         let protocol_color = self.theme().auth_protocol;
-        assert!(
-            self.app
-                .remount(
-                    Id::Remote(AuthFormId::Protocol),
-                    Box::new(components::RemoteProtocolRadio::new(
-                        protocol,
-                        protocol_color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Remote(AuthFormId::Protocol),
+            Box::new(components::RemoteProtocolRadio::new(
+                protocol,
+                protocol_color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_remote_directory<S: AsRef<str>>(
@@ -759,19 +747,17 @@ impl AuthActivity {
     ) {
         let id = Self::form_tab_id(form_tab, AuthFormId::RemoteDirectory);
         let protocol_color = self.theme().auth_protocol;
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputRemoteDirectory::new(
-                        remote_path.as_ref(),
-                        form_tab,
-                        protocol_color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputRemoteDirectory::new(
+                remote_path.as_ref(),
+                form_tab,
+                protocol_color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_local_directory<S: AsRef<str>>(
@@ -781,337 +767,293 @@ impl AuthActivity {
     ) {
         let id = Self::form_tab_id(form_tab, AuthFormId::LocalDirectory);
         let color = self.theme().auth_username;
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputLocalDirectory::new(
-                        local_path.as_ref(),
-                        form_tab,
-                        color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputLocalDirectory::new(
+                local_path.as_ref(),
+                form_tab,
+                color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_address(&mut self, form_tab: FormTab, address: &str) {
         let addr_color = self.theme().auth_address;
         let id = Self::form_tab_id(form_tab, AuthFormId::Address);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputAddress::new(address, form_tab, addr_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputAddress::new(address, form_tab, addr_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_port(&mut self, form_tab: FormTab, port: u16) {
         let port_color = self.theme().auth_port;
         let id = Self::form_tab_id(form_tab, AuthFormId::Port);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputPort::new(port, form_tab, port_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputPort::new(port, form_tab, port_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_username(&mut self, form_tab: FormTab, username: &str) {
         let username_color = self.theme().auth_username;
         let id = Self::form_tab_id(form_tab, AuthFormId::Username);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputUsername::new(
-                        username,
-                        form_tab,
-                        username_color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputUsername::new(
+                username,
+                form_tab,
+                username_color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_password(&mut self, form_tab: FormTab, password: &str) {
         let password_color = self.theme().auth_password;
         let id = Self::form_tab_id(form_tab, AuthFormId::Password);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputPassword::new(
-                        password,
-                        form_tab,
-                        password_color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputPassword::new(
+                password,
+                form_tab,
+                password_color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_s3_bucket(&mut self, form_tab: FormTab, bucket: &str) {
         let addr_color = self.theme().auth_address;
         let id = Self::form_tab_id(form_tab, AuthFormId::S3Bucket);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputS3Bucket::new(bucket, form_tab, addr_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputS3Bucket::new(bucket, form_tab, addr_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_s3_region(&mut self, form_tab: FormTab, region: &str) {
         let port_color = self.theme().auth_port;
         let id = Self::form_tab_id(form_tab, AuthFormId::S3Region);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputS3Region::new(region, form_tab, port_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputS3Region::new(region, form_tab, port_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_s3_endpoint(&mut self, form_tab: FormTab, endpoint: &str) {
         let username_color = self.theme().auth_username;
         let id = Self::form_tab_id(form_tab, AuthFormId::S3Endpoint);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputS3Endpoint::new(
-                        endpoint,
-                        form_tab,
-                        username_color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputS3Endpoint::new(
+                endpoint,
+                form_tab,
+                username_color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_s3_profile(&mut self, form_tab: FormTab, profile: &str) {
         let color = self.theme().auth_password;
         let id = Self::form_tab_id(form_tab, AuthFormId::S3Profile);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputS3Profile::new(profile, form_tab, color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputS3Profile::new(profile, form_tab, color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_s3_access_key(&mut self, form_tab: FormTab, key: &str) {
         let color = self.theme().auth_address;
         let id = Self::form_tab_id(form_tab, AuthFormId::S3AccessKey);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputS3AccessKey::new(key, form_tab, color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputS3AccessKey::new(key, form_tab, color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_s3_secret_access_key(&mut self, form_tab: FormTab, key: &str) {
         let color = self.theme().auth_port;
         let id = Self::form_tab_id(form_tab, AuthFormId::S3SecretAccessKey);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputS3SecretAccessKey::new(
-                        key, form_tab, color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputS3SecretAccessKey::new(
+                key, form_tab, color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_s3_security_token(&mut self, form_tab: FormTab, token: &str) {
         let color = self.theme().auth_username;
         let id = Self::form_tab_id(form_tab, AuthFormId::S3SecurityToken);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputS3SecurityToken::new(
-                        token, form_tab, color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputS3SecurityToken::new(
+                token, form_tab, color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_s3_session_token(&mut self, form_tab: FormTab, token: &str) {
         let color = self.theme().auth_password;
         let id = Self::form_tab_id(form_tab, AuthFormId::S3SessionToken);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputS3SessionToken::new(token, form_tab, color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputS3SessionToken::new(token, form_tab, color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_s3_new_path_style(&mut self, form_tab: FormTab, new_path_style: bool) {
         let color = self.theme().auth_address;
         let id = Self::form_tab_id(form_tab, AuthFormId::S3NewPathStyle);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::RadioS3NewPathStyle::new(
-                        new_path_style,
-                        form_tab,
-                        color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::RadioS3NewPathStyle::new(
+                new_path_style,
+                form_tab,
+                color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_kube_namespace(&mut self, form_tab: FormTab, value: &str) {
         let color = self.theme().auth_port;
         let id = Self::form_tab_id(form_tab, AuthFormId::KubeNamespace);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputKubeNamespace::new(value, form_tab, color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputKubeNamespace::new(value, form_tab, color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_kube_cluster_url(&mut self, form_tab: FormTab, value: &str) {
         let color = self.theme().auth_username;
         let id = Self::form_tab_id(form_tab, AuthFormId::KubeClusterUrl);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputKubeClusterUrl::new(value, form_tab, color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputKubeClusterUrl::new(value, form_tab, color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_kube_username(&mut self, form_tab: FormTab, value: &str) {
         let color = self.theme().auth_password;
         let id = Self::form_tab_id(form_tab, AuthFormId::KubeUsername);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputKubeUsername::new(value, form_tab, color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputKubeUsername::new(value, form_tab, color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_kube_client_cert(&mut self, form_tab: FormTab, value: &str) {
         let color = self.theme().auth_address;
         let id = Self::form_tab_id(form_tab, AuthFormId::KubeClientCert);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputKubeClientCert::new(value, form_tab, color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputKubeClientCert::new(value, form_tab, color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_kube_client_key(&mut self, form_tab: FormTab, value: &str) {
         let color = self.theme().auth_port;
         let id = Self::form_tab_id(form_tab, AuthFormId::KubeClientKey);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputKubeClientKey::new(value, form_tab, color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputKubeClientKey::new(value, form_tab, color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_smb_share(&mut self, form_tab: FormTab, share: &str) {
         let color = self.theme().auth_password;
         let id = Self::form_tab_id(form_tab, AuthFormId::SmbShare);
 
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputSmbShare::new(share, form_tab, color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputSmbShare::new(share, form_tab, color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     #[cfg(posix)]
     pub(super) fn mount_smb_workgroup(&mut self, form_tab: FormTab, workgroup: &str) {
         let color = self.theme().auth_address;
         let id = Self::form_tab_id(form_tab, AuthFormId::SmbWorkgroup);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputSmbWorkgroup::new(
-                        workgroup, form_tab, color
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputSmbWorkgroup::new(
+                workgroup, form_tab, color,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     pub(super) fn mount_webdav_uri(&mut self, form_tab: FormTab, uri: &str) {
         let addr_color = self.theme().auth_address;
         let id = Self::form_tab_id(form_tab, AuthFormId::WebDAVUri);
-        assert!(
-            self.app
-                .remount(
-                    id,
-                    Box::new(components::InputWebDAVUri::new(uri, form_tab, addr_color)),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            id,
+            Box::new(components::InputWebDAVUri::new(uri, form_tab, addr_color)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     fn form_tab_id(form_tab: FormTab, id: AuthFormId) -> Id {
@@ -1992,66 +1934,64 @@ impl AuthActivity {
 
     fn init_global_listener(&mut self) {
         use tuirealm::event::{Key, KeyEvent, KeyModifiers};
-        assert!(
-            self.app
-                .mount(
-                    Id::GlobalListener,
-                    Box::<components::GlobalListener>::default(),
-                    vec![
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Esc,
-                                modifiers: KeyModifiers::NONE,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Function(10),
-                                modifiers: KeyModifiers::NONE,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Char('c'),
-                                modifiers: KeyModifiers::CONTROL,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Char('h'),
-                                modifiers: KeyModifiers::CONTROL,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Function(1),
-                                modifiers: KeyModifiers::NONE,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Char('r'),
-                                modifiers: KeyModifiers::CONTROL,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Char('s'),
-                                modifiers: KeyModifiers::CONTROL,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(SubEventClause::WindowResize, SubClause::Always)
-                    ]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.mount(
+            Id::GlobalListener,
+            Box::<components::GlobalListener>::default(),
+            vec![
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Esc,
+                        modifiers: KeyModifiers::NONE,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Function(10),
+                        modifiers: KeyModifiers::NONE,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Char('c'),
+                        modifiers: KeyModifiers::CONTROL,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Char('h'),
+                        modifiers: KeyModifiers::CONTROL,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Function(1),
+                        modifiers: KeyModifiers::NONE,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Char('r'),
+                        modifiers: KeyModifiers::CONTROL,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Char('s'),
+                        modifiers: KeyModifiers::CONTROL,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(SubEventClause::WindowResize, SubClause::Always),
+            ],
+        ) {
+            error!("Failed to mount component: {err}");
+        }
     }
 
     pub(super) fn get_current_form_tab(&self) -> FormTab {

--- a/src/ui/activities/setup/actions.rs
+++ b/src/ui/activities/setup/actions.rs
@@ -135,7 +135,9 @@ impl SetupActivity {
             error!("Could not leave alternate screen: {}", err);
         }
         // Lock ports
-        assert!(self.app.lock_ports().is_ok());
+        if let Err(err) = self.app.lock_ports() {
+            error!("Failed to lock ports: {err}");
+        }
         // Write key to file
         let res = match edit::edit(placeholder.as_bytes()) {
             Ok(rsa_key) => {
@@ -168,7 +170,9 @@ impl SetupActivity {
                 error!("Could not clear screen screen: {}", err);
             }
             // Unlock ports
-            assert!(self.app.unlock_ports().is_ok());
+            if let Err(err) = self.app.unlock_ports() {
+                error!("Failed to unlock ports: {err}");
+            }
         }
 
         res

--- a/src/ui/activities/setup/config.rs
+++ b/src/ui/activities/setup/config.rs
@@ -71,7 +71,9 @@ impl SetupActivity {
                     error!("Could not leave alternate screen: {}", err);
                 }
                 // Lock ports
-                assert!(self.app.lock_ports().is_ok());
+                if let Err(err) = self.app.lock_ports() {
+                    error!("Failed to lock ports: {err}");
+                }
                 // Get result
                 let result: Result<(), String> = match ctx.config().iter_ssh_keys().nth(idx) {
                     Some(key) => {
@@ -100,7 +102,9 @@ impl SetupActivity {
                     error!("Failed to enter raw mode: {}", err);
                 }
                 // Unlock ports
-                assert!(self.app.unlock_ports().is_ok());
+                if let Err(err) = self.app.unlock_ports() {
+                    error!("Failed to unlock ports: {err}");
+                }
                 // Return result
                 result
             }

--- a/src/ui/activities/setup/update.rs
+++ b/src/ui/activities/setup/update.rs
@@ -103,110 +103,120 @@ impl SetupActivity {
     fn config_update(&mut self, msg: ConfigMsg) -> Option<Msg> {
         match msg {
             ConfigMsg::CheckUpdatesBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Config(IdConfig::PromptOnFileReplace))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::PromptOnFileReplace)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::CheckUpdatesBlurUp => {
-                assert!(self.app.active(&Id::Config(IdConfig::HiddenFiles)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::HiddenFiles)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::DefaultProtocolBlurDown => {
-                assert!(self.app.active(&Id::Config(IdConfig::HiddenFiles)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::HiddenFiles)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::DefaultProtocolBlurUp => {
-                assert!(self.app.active(&Id::Config(IdConfig::TextEditor)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::TextEditor)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::GroupDirsBlurDown => {
-                assert!(self.app.active(&Id::Config(IdConfig::LocalFileFmt)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::LocalFileFmt)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::GroupDirsBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Config(IdConfig::PromptOnFileReplace))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::PromptOnFileReplace)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::HiddenFilesBlurDown => {
-                assert!(self.app.active(&Id::Config(IdConfig::CheckUpdates)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::CheckUpdates)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::HiddenFilesBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Config(IdConfig::DefaultProtocol))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::DefaultProtocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::LocalFileFmtBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Config(IdConfig::RemoteFileFmt))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::RemoteFileFmt)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::LocalFileFmtBlurUp => {
-                assert!(self.app.active(&Id::Config(IdConfig::GroupDirs)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::GroupDirs)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::NotificationsEnabledBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Config(IdConfig::NotificationsThreshold))
-                        .is_ok()
-                );
+                if let Err(err) = self
+                    .app
+                    .active(&Id::Config(IdConfig::NotificationsThreshold))
+                {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::NotificationsEnabledBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Config(IdConfig::RemoteFileFmt))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::RemoteFileFmt)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::NotificationsThresholdBlurDown => {
-                assert!(self.app.active(&Id::Config(IdConfig::SshConfig)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::SshConfig)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::NotificationsThresholdBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Config(IdConfig::NotificationsEnabled))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::NotificationsEnabled)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::PromptOnFileReplaceBlurDown => {
-                assert!(self.app.active(&Id::Config(IdConfig::GroupDirs)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::GroupDirs)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::PromptOnFileReplaceBlurUp => {
-                assert!(self.app.active(&Id::Config(IdConfig::CheckUpdates)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::CheckUpdates)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::RemoteFileFmtBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Config(IdConfig::NotificationsEnabled))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::NotificationsEnabled)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::RemoteFileFmtBlurUp => {
-                assert!(self.app.active(&Id::Config(IdConfig::LocalFileFmt)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::LocalFileFmt)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::TextEditorBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Config(IdConfig::DefaultProtocol))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::DefaultProtocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::TextEditorBlurUp => {
-                assert!(self.app.active(&Id::Config(IdConfig::SshConfig)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::SshConfig)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::SshConfigBlurDown => {
-                assert!(self.app.active(&Id::Config(IdConfig::TextEditor)).is_ok());
+                if let Err(err) = self.app.active(&Id::Config(IdConfig::TextEditor)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::SshConfigBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Config(IdConfig::NotificationsThreshold))
-                        .is_ok()
-                );
+                if let Err(err) = self
+                    .app
+                    .active(&Id::Config(IdConfig::NotificationsThreshold))
+                {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ConfigMsg::ConfigChanged => {
                 self.set_config_changed(true);
@@ -251,10 +261,14 @@ impl SetupActivity {
                 self.mount_new_ssh_key();
             }
             SshMsg::SshHostBlur => {
-                assert!(self.app.active(&Id::Ssh(IdSsh::SshUsername)).is_ok());
+                if let Err(err) = self.app.active(&Id::Ssh(IdSsh::SshUsername)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             SshMsg::SshUsernameBlur => {
-                assert!(self.app.active(&Id::Ssh(IdSsh::SshHost)).is_ok());
+                if let Err(err) = self.app.active(&Id::Ssh(IdSsh::SshHost)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
         }
         None
@@ -263,222 +277,274 @@ impl SetupActivity {
     fn theme_update(&mut self, msg: ThemeMsg) -> Option<Msg> {
         match msg {
             ThemeMsg::AuthAddressBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthPort)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthPort)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthAddressBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthProtocol)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthProtocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthBookmarksBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::AuthRecentHosts))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthRecentHosts)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthBookmarksBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthPassword)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthPassword)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthPasswordBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthBookmarks)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthBookmarks)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthPasswordBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthUsername)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthUsername)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthPortBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthUsername)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthUsername)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthPortBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthAddress)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthAddress)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthProtocolBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthAddress)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthAddress)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthProtocolBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::StatusSync)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::StatusSync)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthRecentHostsBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscError)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscError)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthRecentHostsBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthBookmarks)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthBookmarks)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthUsernameBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthPassword)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthPassword)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::AuthUsernameBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthPort)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthPort)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscErrorBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscInfo)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscInfo)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscErrorBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::AuthRecentHosts))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthRecentHosts)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscInfoBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscInput)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscInput)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscInfoBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscError)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscError)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscInputBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscKeys)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscKeys)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscInputBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscInfo)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscInfo)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscKeysBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscQuit)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscQuit)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscKeysBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscInput)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscInput)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscQuitBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscSave)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscSave)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscQuitBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscKeys)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscKeys)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscSaveBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscWarn)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscWarn)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscSaveBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscQuit)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscQuit)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscWarnBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerLocalBg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerLocalBg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::MiscWarnBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscSave)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscSave)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerLocalBgBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerLocalFg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerLocalFg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerLocalBgBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::MiscWarn)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::MiscWarn)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerLocalFgBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerLocalHg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerLocalHg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerLocalFgBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerLocalBg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerLocalBg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerLocalHgBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerRemoteBg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerRemoteBg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerLocalHgBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerLocalFg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerLocalFg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerRemoteBgBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerRemoteFg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerRemoteFg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerRemoteBgBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerLocalHg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerLocalHg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerRemoteFgBlurDown => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerRemoteHg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerRemoteHg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerRemoteFgBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerRemoteBg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerRemoteBg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerRemoteHgBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::ProgBarFull)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ProgBarFull)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ExplorerRemoteHgBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerRemoteFg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerRemoteFg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ProgBarFullBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::ProgBarPartial)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ProgBarPartial)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ProgBarFullBlurUp => {
-                assert!(
-                    self.app
-                        .active(&Id::Theme(IdTheme::ExplorerRemoteHg))
-                        .is_ok()
-                );
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ExplorerRemoteHg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ProgBarPartialBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::LogBg)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::LogBg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ProgBarPartialBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::ProgBarFull)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ProgBarFull)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::LogBgBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::LogWindow)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::LogWindow)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::LogBgBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::ProgBarPartial)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::ProgBarPartial)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::LogWindowBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::StatusSorting)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::StatusSorting)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::LogWindowBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::LogBg)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::LogBg)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::StatusSortingBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::StatusHidden)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::StatusHidden)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::StatusSortingBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::LogWindow)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::LogWindow)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::StatusHiddenBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::StatusSync)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::StatusSync)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::StatusHiddenBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::StatusSorting)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::StatusSorting)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::StatusSyncBlurDown => {
-                assert!(self.app.active(&Id::Theme(IdTheme::AuthProtocol)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthProtocol)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::StatusSyncBlurUp => {
-                assert!(self.app.active(&Id::Theme(IdTheme::StatusHidden)).is_ok());
+                if let Err(err) = self.app.active(&Id::Theme(IdTheme::StatusHidden)) {
+                    error!("Failed to activate component: {err}");
+                }
             }
             ThemeMsg::ColorChanged(id, color) => {
                 self.action_save_color(id, color);

--- a/src/ui/activities/setup/view/mod.rs
+++ b/src/ui/activities/setup/view/mod.rs
@@ -40,16 +40,16 @@ impl SetupActivity {
 
     /// Mount error box
     pub(super) fn mount_error<S: AsRef<str>>(&mut self, text: S) {
-        assert!(
-            self.app
-                .remount(
-                    Id::Common(IdCommon::ErrorPopup),
-                    Box::new(components::ErrorPopup::new(text)),
-                    vec![],
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::Common(IdCommon::ErrorPopup)).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::Common(IdCommon::ErrorPopup),
+            Box::new(components::ErrorPopup::new(text)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::Common(IdCommon::ErrorPopup)) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount error message
@@ -59,16 +59,16 @@ impl SetupActivity {
 
     /// Mount quit popup
     pub(super) fn mount_quit(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::Common(IdCommon::QuitPopup),
-                    Box::<components::QuitPopup>::default(),
-                    vec![],
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::Common(IdCommon::QuitPopup)).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::Common(IdCommon::QuitPopup),
+            Box::<components::QuitPopup>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::Common(IdCommon::QuitPopup)) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount quit
@@ -78,16 +78,16 @@ impl SetupActivity {
 
     /// Mount save popup
     pub(super) fn mount_save_popup(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::Common(IdCommon::SavePopup),
-                    Box::<components::SavePopup>::default(),
-                    vec![],
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::Common(IdCommon::SavePopup)).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::Common(IdCommon::SavePopup),
+            Box::<components::SavePopup>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::Common(IdCommon::SavePopup)) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount quit
@@ -97,16 +97,16 @@ impl SetupActivity {
 
     /// Mount help
     pub(super) fn mount_help(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::Common(IdCommon::Keybindings),
-                    Box::<components::Keybindings>::default(),
-                    vec![],
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::Common(IdCommon::Keybindings)).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::Common(IdCommon::Keybindings),
+            Box::<components::Keybindings>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::Common(IdCommon::Keybindings)) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount help
@@ -148,96 +148,90 @@ impl SetupActivity {
     /// Mount common components
     fn mount_commons(&mut self, layout: ViewLayout) {
         // Radio tab
-        assert!(
-            self.app
-                .remount(
-                    Id::Common(IdCommon::Header),
-                    Box::new(components::Header::new(layout)),
-                    vec![],
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Common(IdCommon::Header),
+            Box::new(components::Header::new(layout)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Footer
-        assert!(
-            self.app
-                .remount(
-                    Id::Common(IdCommon::Footer),
-                    Box::<components::Footer>::default(),
-                    vec![],
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Common(IdCommon::Footer),
+            Box::<components::Footer>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     /// Mount global listener
     fn mount_global_listener(&mut self) {
-        assert!(
-            self.app
-                .mount(
-                    Id::Common(IdCommon::GlobalListener),
-                    Box::<components::GlobalListener>::default(),
-                    vec![
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Esc,
-                                modifiers: KeyModifiers::NONE,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Function(10),
-                                modifiers: KeyModifiers::NONE,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Tab,
-                                modifiers: KeyModifiers::NONE,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Char('h'),
-                                modifiers: KeyModifiers::CONTROL,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Function(1),
-                                modifiers: KeyModifiers::NONE,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Char('r'),
-                                modifiers: KeyModifiers::CONTROL,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Char('s'),
-                                modifiers: KeyModifiers::CONTROL,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(
-                            SubEventClause::Keyboard(KeyEvent {
-                                code: Key::Function(4),
-                                modifiers: KeyModifiers::NONE,
-                            }),
-                            Self::no_popup_mounted_clause(),
-                        ),
-                        Sub::new(SubEventClause::WindowResize, SubClause::Always)
-                    ]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.mount(
+            Id::Common(IdCommon::GlobalListener),
+            Box::<components::GlobalListener>::default(),
+            vec![
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Esc,
+                        modifiers: KeyModifiers::NONE,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Function(10),
+                        modifiers: KeyModifiers::NONE,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Tab,
+                        modifiers: KeyModifiers::NONE,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Char('h'),
+                        modifiers: KeyModifiers::CONTROL,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Function(1),
+                        modifiers: KeyModifiers::NONE,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Char('r'),
+                        modifiers: KeyModifiers::CONTROL,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Char('s'),
+                        modifiers: KeyModifiers::CONTROL,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(
+                    SubEventClause::Keyboard(KeyEvent {
+                        code: Key::Function(4),
+                        modifiers: KeyModifiers::NONE,
+                    }),
+                    Self::no_popup_mounted_clause(),
+                ),
+                Sub::new(SubEventClause::WindowResize, SubClause::Always),
+            ],
+        ) {
+            error!("Failed to mount component: {err}");
+        }
     }
 
     /// Returns a sub clause which requires that no popup is mounted in order to be satisfied

--- a/src/ui/activities/setup/view/setup.rs
+++ b/src/ui/activities/setup/view/setup.rs
@@ -32,7 +32,9 @@ impl SetupActivity {
         // Load values
         self.load_input_values();
         // Active text editor
-        assert!(self.app.active(&Id::Config(IdConfig::TextEditor)).is_ok());
+        if let Err(err) = self.app.active(&Id::Config(IdConfig::TextEditor)) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     pub(super) fn view_setup(&mut self) {
@@ -145,133 +147,111 @@ impl SetupActivity {
         // Text editor
         let text_editor: String =
             String::from(self.config().get_text_editor().as_path().to_string_lossy());
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::TextEditor),
-                    Box::new(components::TextEditor::new(text_editor.as_str())),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::TextEditor),
+            Box::new(components::TextEditor::new(text_editor.as_str())),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Protocol
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::DefaultProtocol),
-                    Box::new(components::DefaultProtocol::new(
-                        self.config().get_default_protocol()
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::DefaultProtocol),
+            Box::new(components::DefaultProtocol::new(
+                self.config().get_default_protocol(),
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Hidden files
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::HiddenFiles),
-                    Box::new(components::HiddenFiles::new(
-                        self.config().get_show_hidden_files()
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::HiddenFiles),
+            Box::new(components::HiddenFiles::new(
+                self.config().get_show_hidden_files(),
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Updates
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::CheckUpdates),
-                    Box::new(components::CheckUpdates::new(
-                        self.config().get_check_for_updates()
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::CheckUpdates),
+            Box::new(components::CheckUpdates::new(
+                self.config().get_check_for_updates(),
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // File replace
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::PromptOnFileReplace),
-                    Box::new(components::PromptOnFileReplace::new(
-                        self.config().get_prompt_on_file_replace()
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::PromptOnFileReplace),
+            Box::new(components::PromptOnFileReplace::new(
+                self.config().get_prompt_on_file_replace(),
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Group dirs
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::GroupDirs),
-                    Box::new(components::GroupDirs::new(self.config().get_group_dirs())),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::GroupDirs),
+            Box::new(components::GroupDirs::new(self.config().get_group_dirs())),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Local File Fmt
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::LocalFileFmt),
-                    Box::new(components::LocalFileFmt::new(
-                        &self.config().get_local_file_fmt().unwrap_or_default()
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::LocalFileFmt),
+            Box::new(components::LocalFileFmt::new(
+                &self.config().get_local_file_fmt().unwrap_or_default(),
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Remote File Fmt
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::RemoteFileFmt),
-                    Box::new(components::RemoteFileFmt::new(
-                        &self.config().get_remote_file_fmt().unwrap_or_default()
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::RemoteFileFmt),
+            Box::new(components::RemoteFileFmt::new(
+                &self.config().get_remote_file_fmt().unwrap_or_default(),
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Notifications enabled
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::NotificationsEnabled),
-                    Box::new(components::NotificationsEnabled::new(
-                        self.config().get_notifications()
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::NotificationsEnabled),
+            Box::new(components::NotificationsEnabled::new(
+                self.config().get_notifications(),
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Notifications threshold
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::NotificationsThreshold),
-                    Box::new(components::NotificationsThreshold::new(&fmt_bytes(
-                        self.config().get_notification_threshold()
-                    ))),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::NotificationsThreshold),
+            Box::new(components::NotificationsThreshold::new(&fmt_bytes(
+                self.config().get_notification_threshold(),
+            ))),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
         // Ssh config
-        assert!(
-            self.app
-                .remount(
-                    Id::Config(IdConfig::SshConfig),
-                    Box::new(components::SshConfig::new(
-                        self.config().get_ssh_config().unwrap_or("")
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Config(IdConfig::SshConfig),
+            Box::new(components::SshConfig::new(
+                self.config().get_ssh_config().unwrap_or(""),
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     /// Collect values from input and put them into the configuration

--- a/src/ui/activities/setup/view/ssh_keys.rs
+++ b/src/ui/activities/setup/view/ssh_keys.rs
@@ -74,16 +74,16 @@ impl SetupActivity {
 
     /// Mount delete ssh key component
     pub(crate) fn mount_del_ssh_key(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::Ssh(IdSsh::DelSshKeyPopup),
-                    Box::<components::DelSshKeyPopup>::default(),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::Ssh(IdSsh::DelSshKeyPopup)).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::Ssh(IdSsh::DelSshKeyPopup),
+            Box::<components::DelSshKeyPopup>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::Ssh(IdSsh::DelSshKeyPopup)) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount delete ssh key
@@ -93,25 +93,23 @@ impl SetupActivity {
 
     /// Mount new ssh key prompt
     pub(crate) fn mount_new_ssh_key(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::Ssh(IdSsh::SshHost),
-                    Box::<components::SshHost>::default(),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Ssh(IdSsh::SshUsername),
-                    Box::<components::SshUsername>::default(),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::Ssh(IdSsh::SshHost)).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::Ssh(IdSsh::SshHost),
+            Box::<components::SshHost>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Ssh(IdSsh::SshUsername),
+            Box::<components::SshUsername>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::Ssh(IdSsh::SshHost)) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     /// Umount new ssh key prompt
@@ -130,15 +128,15 @@ impl SetupActivity {
                 format!("{username} at {addr}")
             })
             .collect();
-        assert!(
-            self.app
-                .remount(
-                    Id::Ssh(IdSsh::SshKeys),
-                    Box::new(components::SshKeys::new(&keys)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(self.app.active(&Id::Ssh(IdSsh::SshKeys)).is_ok());
+        if let Err(err) = self.app.remount(
+            Id::Ssh(IdSsh::SshKeys),
+            Box::new(components::SshKeys::new(&keys)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.active(&Id::Ssh(IdSsh::SshKeys)) {
+            error!("Failed to activate component: {err}");
+        }
     }
 }

--- a/src/ui/activities/setup/view/theme.rs
+++ b/src/ui/activities/setup/view/theme.rs
@@ -21,7 +21,9 @@ impl SetupActivity {
         // Load styles
         self.load_styles();
         // Active first field
-        assert!(self.app.active(&Id::Theme(IdTheme::AuthProtocol)).is_ok());
+        if let Err(err) = self.app.active(&Id::Theme(IdTheme::AuthProtocol)) {
+            error!("Failed to activate component: {err}");
+        }
     }
 
     pub(super) fn view_theme(&mut self) {
@@ -242,309 +244,247 @@ impl SetupActivity {
     }
 
     fn load_titles(&mut self) {
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::AuthTitle),
-                    Box::<components::AuthTitle>::default(),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::MiscTitle),
-                    Box::<components::MiscTitle>::default(),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::TransferTitle),
-                    Box::<components::TransferTitle>::default(),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::TransferTitle2),
-                    Box::<components::TransferTitle2>::default(),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::AuthTitle),
+            Box::<components::AuthTitle>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::MiscTitle),
+            Box::<components::MiscTitle>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::TransferTitle),
+            Box::<components::TransferTitle>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::TransferTitle2),
+            Box::<components::TransferTitle2>::default(),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 
     /// Load values from theme into input fields
     pub(crate) fn load_styles(&mut self) {
         let theme: Theme = self.theme().clone();
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::AuthAddress),
-                    Box::new(components::AuthAddress::new(theme.auth_address)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::AuthBookmarks),
-                    Box::new(components::AuthBookmarks::new(theme.auth_bookmarks)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::AuthPassword),
-                    Box::new(components::AuthPassword::new(theme.auth_password)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::AuthPort),
-                    Box::new(components::AuthPort::new(theme.auth_port)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::AuthProtocol),
-                    Box::new(components::AuthProtocol::new(theme.auth_protocol)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::AuthRecentHosts),
-                    Box::new(components::AuthRecentHosts::new(theme.auth_recents)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::AuthUsername),
-                    Box::new(components::AuthUsername::new(theme.auth_username)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::MiscError),
-                    Box::new(components::MiscError::new(theme.misc_error_dialog)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::MiscInfo),
-                    Box::new(components::MiscInfo::new(theme.misc_info_dialog)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::MiscInput),
-                    Box::new(components::MiscInput::new(theme.misc_input_dialog)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::MiscKeys),
-                    Box::new(components::MiscKeys::new(theme.misc_keys)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::MiscQuit),
-                    Box::new(components::MiscQuit::new(theme.misc_quit_dialog)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::MiscSave),
-                    Box::new(components::MiscSave::new(theme.misc_save_dialog)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::MiscWarn),
-                    Box::new(components::MiscWarn::new(theme.misc_warn_dialog)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::ExplorerLocalBg),
-                    Box::new(components::ExplorerLocalBg::new(
-                        theme.transfer_local_explorer_background
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::ExplorerLocalFg),
-                    Box::new(components::ExplorerLocalFg::new(
-                        theme.transfer_local_explorer_foreground
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::ExplorerLocalHg),
-                    Box::new(components::ExplorerLocalHg::new(
-                        theme.transfer_local_explorer_highlighted
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::ExplorerRemoteBg),
-                    Box::new(components::ExplorerRemoteBg::new(
-                        theme.transfer_remote_explorer_background
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::ExplorerRemoteFg),
-                    Box::new(components::ExplorerRemoteFg::new(
-                        theme.transfer_remote_explorer_foreground
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::ExplorerRemoteHg),
-                    Box::new(components::ExplorerRemoteHg::new(
-                        theme.transfer_remote_explorer_highlighted
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::ProgBarFull),
-                    Box::new(components::ProgBarFull::new(
-                        theme.transfer_progress_bar_full
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::ProgBarPartial),
-                    Box::new(components::ProgBarPartial::new(
-                        theme.transfer_progress_bar_partial
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::LogBg),
-                    Box::new(components::LogBg::new(theme.transfer_log_background)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::LogWindow),
-                    Box::new(components::LogWindow::new(theme.transfer_log_window)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::StatusSorting),
-                    Box::new(components::StatusSorting::new(
-                        theme.transfer_status_sorting
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::StatusHidden),
-                    Box::new(components::StatusHidden::new(theme.transfer_status_hidden)),
-                    vec![]
-                )
-                .is_ok()
-        );
-        assert!(
-            self.app
-                .remount(
-                    Id::Theme(IdTheme::StatusSync),
-                    Box::new(components::StatusSync::new(
-                        theme.transfer_status_sync_browsing
-                    )),
-                    vec![]
-                )
-                .is_ok()
-        );
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::AuthAddress),
+            Box::new(components::AuthAddress::new(theme.auth_address)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::AuthBookmarks),
+            Box::new(components::AuthBookmarks::new(theme.auth_bookmarks)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::AuthPassword),
+            Box::new(components::AuthPassword::new(theme.auth_password)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::AuthPort),
+            Box::new(components::AuthPort::new(theme.auth_port)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::AuthProtocol),
+            Box::new(components::AuthProtocol::new(theme.auth_protocol)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::AuthRecentHosts),
+            Box::new(components::AuthRecentHosts::new(theme.auth_recents)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::AuthUsername),
+            Box::new(components::AuthUsername::new(theme.auth_username)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::MiscError),
+            Box::new(components::MiscError::new(theme.misc_error_dialog)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::MiscInfo),
+            Box::new(components::MiscInfo::new(theme.misc_info_dialog)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::MiscInput),
+            Box::new(components::MiscInput::new(theme.misc_input_dialog)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::MiscKeys),
+            Box::new(components::MiscKeys::new(theme.misc_keys)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::MiscQuit),
+            Box::new(components::MiscQuit::new(theme.misc_quit_dialog)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::MiscSave),
+            Box::new(components::MiscSave::new(theme.misc_save_dialog)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::MiscWarn),
+            Box::new(components::MiscWarn::new(theme.misc_warn_dialog)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::ExplorerLocalBg),
+            Box::new(components::ExplorerLocalBg::new(
+                theme.transfer_local_explorer_background,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::ExplorerLocalFg),
+            Box::new(components::ExplorerLocalFg::new(
+                theme.transfer_local_explorer_foreground,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::ExplorerLocalHg),
+            Box::new(components::ExplorerLocalHg::new(
+                theme.transfer_local_explorer_highlighted,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::ExplorerRemoteBg),
+            Box::new(components::ExplorerRemoteBg::new(
+                theme.transfer_remote_explorer_background,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::ExplorerRemoteFg),
+            Box::new(components::ExplorerRemoteFg::new(
+                theme.transfer_remote_explorer_foreground,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::ExplorerRemoteHg),
+            Box::new(components::ExplorerRemoteHg::new(
+                theme.transfer_remote_explorer_highlighted,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::ProgBarFull),
+            Box::new(components::ProgBarFull::new(
+                theme.transfer_progress_bar_full,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::ProgBarPartial),
+            Box::new(components::ProgBarPartial::new(
+                theme.transfer_progress_bar_partial,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::LogBg),
+            Box::new(components::LogBg::new(theme.transfer_log_background)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::LogWindow),
+            Box::new(components::LogWindow::new(theme.transfer_log_window)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::StatusSorting),
+            Box::new(components::StatusSorting::new(
+                theme.transfer_status_sorting,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::StatusHidden),
+            Box::new(components::StatusHidden::new(theme.transfer_status_hidden)),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
+        if let Err(err) = self.app.remount(
+            Id::Theme(IdTheme::StatusSync),
+            Box::new(components::StatusSync::new(
+                theme.transfer_status_sync_browsing,
+            )),
+            vec![],
+        ) {
+            error!("Failed to remount component: {err}");
+        }
     }
 }


### PR DESCRIPTION
## Summary
- Replace ~312 `assert!` calls in UI activity update/view files with `if let Err` error logging
- Prevents application crashes when UI component operations fail (active, mount, remount, umount, lock_ports, unlock_ports)
- Affected files:
  - `src/ui/activities/auth/update.rs` (113 replacements)
  - `src/ui/activities/auth/view.rs` (55 replacements)
  - `src/ui/activities/setup/update.rs` (78 replacements)
  - `src/ui/activities/setup/view/theme.rs` (32 replacements)
  - `src/ui/activities/setup/view/setup.rs` (12 replacements)
  - `src/ui/activities/setup/view/mod.rs` (11 replacements)
  - `src/ui/activities/setup/view/ssh_keys.rs` (7 replacements)
  - `src/ui/activities/setup/actions.rs` (2 replacements)
  - `src/ui/activities/setup/config.rs` (2 replacements)

## Test plan
- [x] `cargo build --no-default-features` passes
- [x] `cargo clippy --no-default-features -- -Dwarnings` passes
- [x] `cargo test --no-default-features --features github-actions --no-fail-fast` passes (210/211 tests pass; 1 known flaky test in `system::logging`)