### PR TITLE
fix: correct typos and naming issues

### DIFF
--- a/src/system/keys/keyringstorage.rs
+++ b/src/system/keys/keyringstorage.rs
@@ -37,7 +37,7 @@ impl KeyStorage for KeyringStorage {
                 | KeyringError::Invalid(_, _)
                 | KeyringError::Ambiguous(_) => Err(KeyStorageError::ProviderError),
                 KeyringError::BadEncoding(_) | KeyringError::TooLong(_, _) => {
-                    Err(KeyStorageError::BadSytax)
+                    Err(KeyStorageError::BadSyntax)
                 }
                 _ => Err(KeyStorageError::ProviderError),
             },

--- a/src/system/keys/mod.rs
+++ b/src/system/keys/mod.rs
@@ -13,7 +13,7 @@ use thiserror::Error;
 #[derive(Debug, Error)]
 pub enum KeyStorageError {
     #[error("Key has a bad syntax")]
-    BadSytax,
+    BadSyntax,
     #[error("Provider service error")]
     ProviderError,
     #[error("No such key")]
@@ -54,7 +54,7 @@ mod tests {
     #[test]
     fn test_system_keys_mod_errors() {
         assert_eq!(
-            KeyStorageError::BadSytax.to_string(),
+            KeyStorageError::BadSyntax.to_string(),
             String::from("Key has a bad syntax")
         );
         assert_eq!(

--- a/src/system/theme_provider.rs
+++ b/src/system/theme_provider.rs
@@ -23,7 +23,7 @@ impl ThemeProvider {
     pub fn new(theme_path: &Path) -> Result<Self, SerializerError> {
         let default_theme: Theme = Theme::default();
         info!(
-            "Setting up theme provider with thene path {} ",
+            "Setting up theme provider with theme path {}",
             theme_path.display(),
         );
         // Create provider
@@ -42,7 +42,7 @@ impl ThemeProvider {
         } else {
             // otherwise Load configuration from file
             if let Err(err) = provider.load() {
-                error!("Couldn't read thene file: {}", err);
+                error!("Couldn't read theme file: {}", err);
                 return Err(err);
             }
             debug!("Read theme file");

--- a/src/ui/activities/setup/view/theme.rs
+++ b/src/ui/activities/setup/view/theme.rs
@@ -12,7 +12,7 @@ use super::{Context, Id, IdCommon, IdTheme, SetupActivity, Theme, ViewLayout, co
 impl SetupActivity {
     // -- view
 
-    /// Initialize thene view
+    /// Initialize theme view
     pub(super) fn init_theme(&mut self) {
         // Init view (and mount commons)
         self.new_app(ViewLayout::Theme);


### PR DESCRIPTION
## Summary
- Rename `BadSytax` to `BadSyntax` in `KeyStorageError` enum
- Fix "thene" -> "theme" typos in theme_provider.rs log messages
- Fix "thene" -> "theme" typo in setup view theme.rs doc comment

## Test plan
- [x] cargo build --no-default-features passes
- [x] cargo clippy --no-default-features -- -Dwarnings passes
- [x] cargo test --no-default-features --features github-actions --no-fail-fast passes (1 known flaky test in system::environment::tests excluded)