### PR TITLE
perf: optimize file sorting and reduce unnecessary allocations

### DIFF
--- a/src/explorer/mod.rs
+++ b/src/explorer/mod.rs
@@ -245,7 +245,8 @@ impl FileExplorer {
 
     /// Sort explorer files by their name. All names are converted to lowercase
     fn sort_files_by_name(&mut self) {
-        self.files.sort_by_key(|x: &File| x.name().to_lowercase());
+        self.files
+            .sort_by_cached_key(|x: &File| x.name().to_lowercase());
     }
 
     /// Sort files by mtime; the newest comes first


### PR DESCRIPTION
## Summary
- Replace `sort_by_key` with `sort_by_cached_key` in `sort_files_by_name()`
- This caches the lowercase key for each file, avoiding repeated String allocations during sort comparisons
- For a directory with N files, reduces from O(N log N) lowercase allocations to O(N)

## Test plan
- [x] cargo build --no-default-features passes
- [x] cargo clippy --no-default-features -- -Dwarnings passes
- [x] cargo test --no-default-features --features github-actions --no-fail-fast passes