### PR TITLE
chore: add centralized lint configuration and fix lint warnings

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,6 +117,18 @@ keyring = []
 smb = ["dep:remotefs-smb"]
 smb-vendored = ["remotefs-smb/vendored"]
 
+[lints.rust]
+trivial_numeric_casts = "warn"
+unsafe_op_in_unsafe_fn = "warn"
+unused_lifetimes = "warn"
+
+[lints.clippy]
+complexity = { level = "warn", priority = -1 }
+correctness = { level = "warn", priority = -1 }
+perf = { level = "warn", priority = -1 }
+style = { level = "warn", priority = -1 }
+suspicious = { level = "warn", priority = -1 }
+
 [profile.dev]
 incremental = true
 


### PR DESCRIPTION
## Summary
- Add `[lints.rust]` and `[lints.clippy]` sections to Cargo.toml
- Enable clippy lint groups: complexity, correctness, perf, style, suspicious
- Enable rust lints: trivial_numeric_casts, unsafe_op_in_unsafe_fn, unused_lifetimes
- Fix all resulting warnings

## Test plan
- [x] cargo build --no-default-features passes
- [x] cargo clippy --no-default-features -- -Dwarnings passes
- [x] cargo test --no-default-features --features github-actions --no-fail-fast passes