### PR TITLE
refactor: replace lazy_static with std::sync::LazyLock

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4640,7 +4640,6 @@ dependencies = [
  "hostname",
  "keyring",
  "lazy-regex",
- "lazy_static",
  "log",
  "magic-crypt",
  "notify",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,6 @@ keyring = { version = "^3", features = [
   "vendored",
 ] }
 lazy-regex = "^3"
-lazy_static = "^1"
 log = "^0.4"
 magic-crypt = "4"
 notify = "8"

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,8 +15,6 @@ extern crate bitflags;
 #[macro_use]
 extern crate lazy_regex;
 #[macro_use]
-extern crate lazy_static;
-#[macro_use]
 extern crate log;
 #[macro_use]
 extern crate magic_crypt;

--- a/src/system/environment.rs
+++ b/src/system/environment.rs
@@ -4,20 +4,21 @@
 
 // Ext
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+
+#[cfg(not(test))]
+static CONF_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(dirs::config_dir);
+#[cfg(test)]
+static CONF_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(|| Some(std::env::temp_dir()));
+
+#[cfg(not(test))]
+static CACHE_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(dirs::cache_dir);
+#[cfg(test)]
+static CACHE_DIR: LazyLock<Option<PathBuf>> = LazyLock::new(|| Some(std::env::temp_dir()));
 
 /// Get termscp config directory path and initialize it.
 /// Returns None if it's not possible to initialize it
 pub fn init_config_dir() -> Result<Option<PathBuf>, String> {
-    // Get file
-    #[cfg(not(test))]
-    lazy_static! {
-        static ref CONF_DIR: Option<PathBuf> = dirs::config_dir();
-    }
-    #[cfg(test)]
-    lazy_static! {
-        static ref CONF_DIR: Option<PathBuf> = Some(std::env::temp_dir());
-    }
-
     if let Some(dir) = CONF_DIR.as_deref() {
         init_dir(dir).map(Option::Some)
     } else {
@@ -28,16 +29,6 @@ pub fn init_config_dir() -> Result<Option<PathBuf>, String> {
 /// Get termscp cache directory path and initialize it.
 /// Returns None if it's not possible to initialize it
 pub fn init_cache_dir() -> Result<Option<PathBuf>, String> {
-    // Get file
-    #[cfg(not(test))]
-    lazy_static! {
-        static ref CACHE_DIR: Option<PathBuf> = dirs::cache_dir();
-    }
-    #[cfg(test)]
-    lazy_static! {
-        static ref CACHE_DIR: Option<PathBuf> = Some(std::env::temp_dir());
-    }
-
     if let Some(dir) = CACHE_DIR.as_deref() {
         init_dir(dir).map(Option::Some)
     } else {


### PR DESCRIPTION
## Summary
- Replace all `lazy_static!` macro usages with `std::sync::LazyLock`
- Remove `lazy_static` dependency from Cargo.toml
- `LazyLock` has been stable since Rust 1.80.0, well within the project's MSRV of 1.89.0

## Test plan
- [x] cargo build --no-default-features passes
- [x] cargo clippy --no-default-features -- -Dwarnings passes
- [x] cargo test --no-default-features --features github-actions --no-fail-fast passes