### PR TITLE
fix: resolve cd .. panic and exec argument dropping in terminal mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -106,4 +106,5 @@ Platform-specific dependencies: SSH and FTP crates use different TLS backends on
 
 ## Other conventions
 
+- Always run `cargo +nightly fmt --all` and `cargo clippy --no-default-features -- -Dwarnings` after modifying Rust code
 - Always put plans to `./.claude/plans/`

--- a/src/filetransfer/remotefs_builder.rs
+++ b/src/filetransfer/remotefs_builder.rs
@@ -13,8 +13,10 @@ use remotefs_kube::KubeMultiPodFs as KubeFs;
 use remotefs_smb::SmbOptions;
 #[cfg(smb)]
 use remotefs_smb::{SmbCredentials, SmbFs};
-use remotefs_ssh::{NoCheckServerKey, RusshSession as SshSession};
-use remotefs_ssh::{ScpFs, SftpFs, SshAgentIdentity, SshConfigParseRule, SshOpts};
+use remotefs_ssh::{
+    NoCheckServerKey, RusshSession as SshSession, ScpFs, SftpFs, SshAgentIdentity,
+    SshConfigParseRule, SshOpts,
+};
 use remotefs_webdav::WebDAVFs;
 
 #[cfg(not(smb))]

--- a/src/ui/activities/filetransfer/actions/exec.rs
+++ b/src/ui/activities/filetransfer/actions/exec.rs
@@ -30,7 +30,7 @@ impl FromStr for Command {
                 }
             }
             Some("exit") | Some("logout") => Ok(Command::Exit),
-            Some(cmd) => Ok(Command::Exec(cmd.to_string())),
+            Some(_) => Ok(Command::Exec(s.to_string())),
             None => Err("".to_string()),
         }
     }

--- a/src/utils/fmt.rs
+++ b/src/utils/fmt.rs
@@ -67,8 +67,10 @@ pub fn fmt_path_elide_ex(p: &Path, width: usize, extra_len: usize) -> String {
             // If ancestors_len is bigger than 3, push '…' and parent too
             if ancestors_len > 3 {
                 elided_path.push("…");
-                if let Some(parent) = p.ancestors().nth(1) {
-                    elided_path.push(parent.file_name().unwrap());
+                if let Some(parent) = p.ancestors().nth(1)
+                    && let Some(name) = parent.file_name()
+                {
+                    elided_path.push(name);
                 }
             }
             // Push file_name

--- a/src/utils/path.rs
+++ b/src/utils/path.rs
@@ -12,14 +12,34 @@ use std::path::{Component, Path, PathBuf};
 /// assert_eq!(absolutize(&Path::new("/home/omar"), &Path::new("/tmp/readme.txt")).as_path(), Path::new("/tmp/readme.txt"));
 /// ```
 pub fn absolutize(wrkdir: &Path, target: &Path) -> PathBuf {
-    match target.is_absolute() {
+    let raw = match target.is_absolute() {
         true => target.to_path_buf(),
         false => {
             let mut p: PathBuf = wrkdir.to_path_buf();
             p.push(target);
             p
         }
+    };
+    normalize(&raw)
+}
+
+/// Normalize a path by resolving `.` and `..` components lexically
+/// (without touching the filesystem).
+fn normalize(path: &Path) -> PathBuf {
+    let mut parts: Vec<Component> = Vec::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                // Pop the last normal component; never pop past root
+                if let Some(Component::Normal(_)) = parts.last() {
+                    parts.pop();
+                }
+            }
+            Component::CurDir => {} // skip `.`
+            other => parts.push(other),
+        }
     }
+    parts.iter().collect()
 }
 
 /// This function will get the difference from path `path` to `base`. Basically will remove `base` from `path`
@@ -97,6 +117,44 @@ mod test {
             absolutize(Path::new("/home/omar"), Path::new("/tmp/readme.txt")).as_path(),
             Path::new("/tmp/readme.txt")
         );
+    }
+
+    #[test]
+    fn absolutize_resolves_parent_dir() {
+        assert_eq!(
+            absolutize(Path::new("/home/omar"), Path::new("..")).as_path(),
+            Path::new("/home")
+        );
+        assert_eq!(
+            absolutize(Path::new("/home/omar"), Path::new("../docs")).as_path(),
+            Path::new("/home/docs")
+        );
+        assert_eq!(
+            absolutize(Path::new("/home"), Path::new("..")).as_path(),
+            Path::new("/")
+        );
+    }
+
+    #[test]
+    fn absolutize_resolves_current_dir() {
+        assert_eq!(
+            absolutize(Path::new("/home/omar"), Path::new(".")).as_path(),
+            Path::new("/home/omar")
+        );
+        assert_eq!(
+            absolutize(Path::new("/home/omar"), Path::new("./docs")).as_path(),
+            Path::new("/home/omar/docs")
+        );
+    }
+
+    #[test]
+    fn normalize_path() {
+        assert_eq!(normalize(Path::new("/a/b/../c")), Path::new("/a/c"));
+        assert_eq!(normalize(Path::new("/a/b/./c")), Path::new("/a/b/c"));
+        assert_eq!(normalize(Path::new("/a/b/c/../..")), Path::new("/a"));
+        assert_eq!(normalize(Path::new("/")), Path::new("/"));
+        // Parent beyond root stays at root
+        assert_eq!(normalize(Path::new("/..")), Path::new("/"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Fix `cd ..` / `cd .` in terminal mode causing a panic by lexically normalizing paths in `absolutize` (resolves `..` and `.` components)
- Guard `fmt_path_elide_ex` against `file_name()` returning `None`, which was the direct cause of the `unwrap()` panic at `fmt.rs:71`
- Fix `Exec` command parsing dropping all arguments after the first word (e.g. `ls -la /tmp` was executed as just `ls`)

## Test plan
- [x] New unit tests for `absolutize` with `..` and `.` paths
- [x] New unit tests for `normalize`
- [x] Existing `fmt_path_elide` tests still pass
- [x] Clippy clean, nightly fmt clean

Closes #402

🤖 Generated with [Claude Code](https://claude.com/claude-code)