### PR TITLE
fix: sync browsing when entering a directory from filtered view

### DIFF
--- a/src/ui/activities/filetransfer/actions/change_dir.rs
+++ b/src/ui/activities/filetransfer/actions/change_dir.rs
@@ -10,7 +10,7 @@ use remotefs::File;
 use super::{FileTransferActivity, LogLevel, Msg, PendingActionMsg};
 
 /// Describes destination for sync browsing
-enum SyncBrowsingDestination {
+pub(crate) enum SyncBrowsingDestination {
     Path(String),
     ParentDir,
     PreviousDir,
@@ -63,7 +63,7 @@ impl FileTransferActivity {
 
     /// Synchronize browsing on the target browser.
     /// If destination doesn't exist, then prompt for directory creation.
-    fn synchronize_browsing(&mut self, destination: SyncBrowsingDestination) {
+    pub(crate) fn synchronize_browsing(&mut self, destination: SyncBrowsingDestination) {
         // Get destination path
         let path = match self.resolve_sync_browsing_destination(&destination) {
             Some(p) => p,

--- a/src/ui/activities/filetransfer/actions/find.rs
+++ b/src/ui/activities/filetransfer/actions/find.rs
@@ -5,6 +5,7 @@
 // locals
 use std::path::PathBuf;
 
+use super::change_dir::SyncBrowsingDestination;
 use super::{File, FileTransferActivity, LogLevel, SelectedFile, TransferOpts, TransferPayload};
 
 impl FileTransferActivity {
@@ -23,6 +24,14 @@ impl FileTransferActivity {
             };
             // Change directory on the active tab's pane
             self.pane_changedir(path.as_path(), true);
+            // Sync browsing: mirror the directory change on the opposite pane
+            if self.browser.sync_browsing {
+                let dir_name = path
+                    .file_name()
+                    .map(|n| n.to_string_lossy().to_string())
+                    .unwrap_or_default();
+                self.synchronize_browsing(SyncBrowsingDestination::Path(dir_name));
+            }
         }
     }
 

--- a/src/ui/activities/filetransfer/update.rs
+++ b/src/ui/activities/filetransfer/update.rs
@@ -120,7 +120,10 @@ impl FileTransferActivity {
                 self.umount_find();
                 // Finalize find
                 self.finalize_find();
-                // Reload files
+                // Reload files; update opposite pane too when sync browsing
+                if self.browser.sync_browsing {
+                    self.update_browser_file_list_swapped();
+                }
                 self.update_browser_file_list()
             }
             TransferMsg::ExecuteCmd(cmd) => {


### PR DESCRIPTION
## Summary

- Fixes sync browsing not triggering when entering a directory from a filtered (`/`) view
- Reuses existing `synchronize_browsing` logic (including mkdir prompt on the opposite pane) by making it `pub(crate)`

Closes #382

## Test plan

- [ ] Enable sync browsing between local and remote with matching directory structures
- [ ] Use `/` to filter directories, enter one, and verify both panes navigate
- [ ] Verify normal (non-filtered) sync browsing still works as before
- [ ] Verify the mkdir prompt still appears if the directory doesn't exist on the opposite side