### PR TITLE
Migrate system keyring to the new supported version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,8 @@ jobs:
         with:
           ref: ${{ inputs.dry_run && github.sha || 'main' }}
           persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
         with:
           targets: ${{ matrix.target }}
@@ -382,6 +384,8 @@ jobs:
         with:
           ref: main
           persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8 # stable
 
       - name: Install dependencies (Linux)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,6 +111,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7be2f067ccd8d4b4d4a66ddafe0f32a5dff31732f32dbff85fefc40929b1f72"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "approx"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1417,9 +1428,27 @@ version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "708b509edf7889e53d7efb0ffadd994cc6c2345ccb62f55cfd6b0682165e4fa6"
 dependencies = [
+ "aes 0.8.4",
+ "block-padding 0.3.3",
+ "cbc 0.1.2",
  "dbus",
+ "fastrand",
+ "hkdf 0.12.4",
+ "num",
+ "once_cell",
  "openssl",
+ "sha2 0.10.9",
  "zeroize",
+]
+
+[[package]]
+name = "dbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21d8f54da401bb5eb2a4d873ac4b359f4a599df2ca8634bb5b8c045e5ee78757"
+dependencies = [
+ "dbus-secret-service",
+ "keyring-core",
 ]
 
 [[package]]
@@ -2973,19 +3002,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "keyring"
-version = "3.6.3"
+name = "keyring-core"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
 dependencies = [
- "byteorder",
- "dbus-secret-service",
  "log",
- "openssl",
- "security-framework 2.11.1",
- "security-framework 3.7.0",
- "windows-sys 0.60.2",
- "zeroize",
 ]
 
 [[package]]
@@ -3464,6 +3486,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3490,6 +3526,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3511,6 +3556,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
 dependencies = [
  "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-rational"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f83d14da390562dca69fc84082e73e548e1ad308d24accdedd2720017cb37824"
+dependencies = [
+ "num-bigint",
  "num-integer",
  "num-traits",
 ]
@@ -6164,6 +6220,7 @@ version = "1.0.0"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.10.3",
+ "apple-native-keyring-store",
  "argh",
  "base64 0.22.1",
  "bitflags 2.13.0",
@@ -6172,10 +6229,11 @@ dependencies = [
  "cfg_aliases",
  "chrono",
  "content_inspector",
+ "dbus-secret-service-keyring-store",
  "dirs",
  "edit",
  "filetime",
- "keyring",
+ "keyring-core",
  "lazy-regex",
  "log",
  "md-5 0.11.0",
@@ -6213,6 +6271,7 @@ dependencies = [
  "vergen-git2",
  "whoami",
  "wildmatch",
+ "windows-native-keyring-store",
 ]
 
 [[package]]
@@ -7274,6 +7333,19 @@ name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
 
 [[package]]
 name = "windows-numerics"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6216,7 +6216,7 @@ dependencies = [
 
 [[package]]
 name = "termscp"
-version = "1.0.0"
+version = "1.1.0"
 dependencies = [
  "aes 0.9.1",
  "aes-gcm 0.10.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -221,7 +221,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "hex",
- "http 1.4.1",
+ "http 1.4.2",
  "ring",
  "time",
  "tokio",
@@ -283,7 +283,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "percent-encoding",
@@ -317,7 +317,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "lru 0.16.4",
  "percent-encoding",
@@ -346,7 +346,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -370,7 +370,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -395,7 +395,7 @@ dependencies = [
  "aws-types",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "regex-lite",
  "tracing",
 ]
@@ -417,7 +417,7 @@ dependencies = [
  "hex",
  "hmac 0.12.1",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "p256 0.11.1",
  "percent-encoding",
  "ring",
@@ -450,10 +450,10 @@ dependencies = [
  "bytes",
  "crc-fast",
  "hex",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
- "md-5",
+ "md-5 0.10.6",
  "pin-project-lite",
  "sha1 0.10.6",
  "sha2 0.10.9",
@@ -484,7 +484,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "percent-encoding",
@@ -505,7 +505,7 @@ dependencies = [
  "h2 0.3.27",
  "h2 0.4.14",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "hyper 0.14.32",
  "hyper 1.10.1",
@@ -566,7 +566,7 @@ dependencies = [
  "bytes",
  "fastrand",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -586,7 +586,7 @@ dependencies = [
  "aws-smithy-types",
  "bytes",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "pin-project-lite",
  "tokio",
  "tracing",
@@ -604,7 +604,7 @@ dependencies = [
  "bytes-utils",
  "futures-core",
  "http 0.2.12",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 0.4.6",
  "http-body 1.0.1",
  "http-body-util",
@@ -801,6 +801,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bon"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f47dbe92550676ee653353c310dfb9cf6ba17ee70396e1f7cf0a2020ad49b2fe"
+dependencies = [
+ "bon-macros",
+ "rustversion",
+]
+
+[[package]]
+name = "bon-macros"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
+dependencies = [
+ "darling",
+ "ident_case",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "rustversion",
+ "syn",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -847,39 +872,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86566c496f2f47d9b8147a4c8b02ffdb69c919fe0c2b2e7195d22cbba0e635c9"
 dependencies = [
  "bytes",
-]
-
-[[package]]
-name = "camino"
-version = "1.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
-name = "cargo-platform"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87a0c0e6148f11f01f32650a2ea02d532b2ad4e81d8bd41e6e565b5adc5e6082"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
-name = "cargo_metadata"
-version = "0.23.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef987d17b0a113becdd19d3d0022d04d7ef41f9efe4f3fb63ac44ba61df3ade9"
-dependencies = [
- "camino",
- "cargo-platform",
- "semver",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -1356,36 +1348,12 @@ dependencies = [
 
 [[package]]
 name = "darling"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7f46116c46ff9ab3eb1597a45688b6715c6e628b5c133e288e709a29bcb4ee"
-dependencies = [
- "darling_core 0.20.11",
- "darling_macro 0.20.11",
-]
-
-[[package]]
-name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
 dependencies = [
- "darling_core 0.23.0",
- "darling_macro 0.23.0",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d00b9596d185e565c2207a0b01f8bd1a135483d02d9b7b0a54b11da8d53412e"
-dependencies = [
- "fnv",
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
+ "darling_core",
+ "darling_macro",
 ]
 
 [[package]]
@@ -1403,22 +1371,11 @@ dependencies = [
 
 [[package]]
 name = "darling_macro"
-version = "0.20.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
-dependencies = [
- "darling_core 0.20.11",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
- "darling_core 0.23.0",
+ "darling_core",
  "quote",
  "syn",
 ]
@@ -1525,37 +1482,6 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "507dfb09ea8b7fa618fcf76e953f4f5e192547945816d5358edffe39f6f94947"
-dependencies = [
- "derive_builder_macro",
-]
-
-[[package]]
-name = "derive_builder_core"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2d5bcf7b024d6835cfb3d473887cd966994907effbe9227e8c8219824d06c4e8"
-dependencies = [
- "darling 0.20.11",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "derive_builder_macro"
-version = "0.20.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
-dependencies = [
- "derive_builder_core",
  "syn",
 ]
 
@@ -2237,6 +2163,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "git2"
+version = "0.21.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
+dependencies = [
+ "bitflags 2.13.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,7 +2255,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.4.1",
+ "http 1.4.2",
  "indexmap",
  "slab",
  "tokio",
@@ -2371,7 +2309,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.4.1",
+ "http 1.4.2",
  "httpdate",
  "mime",
  "sha1 0.10.6",
@@ -2383,7 +2321,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.4.1",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -2462,9 +2400,9 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "1.4.1"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be7462df143984c4598a256ef469b251d7d7f9e271135073e78fc535414f3d0"
+checksum = "6970f50e31d6fc17d3fa27329444bfa74e196cf62e95052a3f6fee181dba6425"
 dependencies = [
  "bytes",
  "itoa",
@@ -2488,7 +2426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.4.1",
+ "http 1.4.2",
 ]
 
 [[package]]
@@ -2499,7 +2437,7 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
 ]
@@ -2563,7 +2501,7 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "h2 0.4.14",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "httparse",
  "itoa",
@@ -2582,7 +2520,7 @@ dependencies = [
  "bytes",
  "futures-util",
  "headers",
- "http 1.4.1",
+ "http 1.4.2",
  "hyper 1.10.1",
  "hyper-rustls 0.27.9",
  "hyper-util",
@@ -2614,7 +2552,7 @@ version = "0.27.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
 dependencies = [
- "http 1.4.1",
+ "http 1.4.2",
  "hyper 1.10.1",
  "hyper-util",
  "log",
@@ -2662,7 +2600,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "hyper 1.10.1",
  "ipnet",
@@ -2894,7 +2832,7 @@ version = "0.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5eb2d60ef19920a3a9193c3e371f726ec1dafc045dac788d0fb3704272458971"
 dependencies = [
- "darling 0.23.0",
+ "darling",
  "indoc",
  "proc-macro2",
  "quote",
@@ -3093,7 +3031,7 @@ dependencies = [
  "either",
  "futures",
  "home",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
@@ -3129,7 +3067,7 @@ checksum = "40fb9bd8141cbc0fe6b0d9112d371679b4cb607b45c31dd68d92e40864a12975"
 dependencies = [
  "chrono",
  "form_urlencoded",
- "http 1.4.1",
+ "http 1.4.2",
  "k8s-openapi",
  "serde",
  "serde_json",
@@ -3337,6 +3275,16 @@ checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
  "digest 0.10.7",
+]
+
+[[package]]
+name = "md-5"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69b6441f590336821bb897fb28fc622898ccceb1d6cea3fde5ea86b090c4de98"
+dependencies = [
+ "cfg-if",
+ "digest 0.11.3",
 ]
 
 [[package]]
@@ -3639,6 +3587,17 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
 ]
 
 [[package]]
@@ -3973,7 +3932,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30b8c63418f1e7dfbb786268ae0927537b87d90b1211216c1ba50ce25d8d9495"
 dependencies = [
  "cc",
- "git2",
+ "git2 0.20.4",
  "glob",
 ]
 
@@ -4745,9 +4704,9 @@ dependencies = [
 
 [[package]]
 name = "remotefs-ssh"
-version = "0.8.4"
+version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73c3eee1ec0e33cafe7a3809bae0652f2b764049e73b1ef9df4f768a31aa9dd8"
+checksum = "7fa1336153fb7e11d6cf013b279aae115a8454d9f496afb7bccaab1466085253"
 dependencies = [
  "chrono",
  "lazy-regex",
@@ -4769,7 +4728,7 @@ checksum = "5d2b34f3ac2069b106c65b2d0c91b9b4b24a0b5fe9585b49f50fff4135f2cff8"
 dependencies = [
  "bytes",
  "bytestring",
- "http 1.4.1",
+ "http 1.4.2",
  "httpdate",
  "indexmap",
  "log",
@@ -4834,7 +4793,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "h2 0.4.14",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.10.1",
@@ -5533,10 +5492,6 @@ name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
-dependencies = [
- "serde",
- "serde_core",
-]
 
 [[package]]
 name = "serde"
@@ -6019,7 +5974,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.13.0",
  "dirs",
- "git2",
+ "git2 0.20.4",
  "glob",
  "log",
  "thiserror 2.0.18",
@@ -6073,9 +6028,9 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "suppaftp"
-version = "8.0.3"
+version = "8.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4275c142b5be3af2eeadd70dd368caf3b65546c8af1035839372dd7a1436127d"
+checksum = "4cf00e4d8418c477a8cb3c13ae5396a68d31658e760c74280bdbd34926e3b94b"
 dependencies = [
  "chrono",
  "futures-lite",
@@ -6124,16 +6079,17 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.39.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "21d0d938c10fcda3e897e28aaddf4ab462375d411f4378cd63b1c945f69aba96"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
- "windows 0.61.3",
+ "objc2-open-directory",
+ "windows 0.62.2",
 ]
 
 [[package]]
@@ -6206,13 +6162,13 @@ dependencies = [
 name = "termscp"
 version = "1.0.0"
 dependencies = [
- "aes 0.8.4",
+ "aes 0.9.1",
  "aes-gcm 0.10.3",
  "argh",
  "base64 0.22.1",
  "bitflags 2.13.0",
  "bytesize",
- "cbc 0.1.2",
+ "cbc 0.2.1",
  "cfg_aliases",
  "chrono",
  "content_inspector",
@@ -6222,13 +6178,13 @@ dependencies = [
  "keyring",
  "lazy-regex",
  "log",
- "md-5",
+ "md-5 0.11.0",
  "notify",
  "notify-rust",
  "nucleo",
  "open",
  "pretty_assertions",
- "rand 0.9.4",
+ "rand 0.10.1",
  "regex",
  "remotefs",
  "remotefs-aws-s3",
@@ -6543,7 +6499,7 @@ dependencies = [
  "base64 0.21.7",
  "bitflags 2.13.0",
  "bytes",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "http-body-util",
  "mime",
@@ -6562,7 +6518,7 @@ dependencies = [
  "bitflags 2.13.0",
  "bytes",
  "futures-util",
- "http 1.4.1",
+ "http 1.4.2",
  "http-body 1.0.1",
  "pin-project-lite",
  "tower 0.5.3",
@@ -6678,7 +6634,7 @@ dependencies = [
  "byteorder",
  "bytes",
  "data-encoding",
- "http 1.4.1",
+ "http 1.4.2",
  "httparse",
  "log",
  "rand 0.8.6",
@@ -6836,14 +6792,12 @@ checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "vergen"
-version = "9.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b849a1f6d8639e8de261e81ee0fc881e3e3620db1af9f2e0da015d4382ceaf75"
+checksum = "7bdf18a54cf91b4d98a8e8b67f6321606539fbcdcac02536286ad1de37b53fd2"
 dependencies = [
  "anyhow",
- "cargo_metadata",
- "derive_builder",
- "regex",
+ "bon",
  "rustc_version",
  "rustversion",
  "sysinfo",
@@ -6853,13 +6807,13 @@ dependencies = [
 
 [[package]]
 name = "vergen-git2"
-version = "9.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d51ab55ddf1188c8d679f349775362b0fa9e90bd7a4ac69838b2a087623f0d57"
+checksum = "b6e1ddb3075d894c0796fa8e592b778b1a6c034cb95d254372e5c2270adbfbfe"
 dependencies = [
  "anyhow",
- "derive_builder",
- "git2",
+ "bon",
+ "git2 0.21.0",
  "rustversion",
  "time",
  "vergen",
@@ -6868,12 +6822,12 @@ dependencies = [
 
 [[package]]
 name = "vergen-lib"
-version = "9.1.0"
+version = "10.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b34a29ba7e9c59e62f229ae1932fb1b8fb8a6fdcc99215a641913f5f5a59a569"
+checksum = "910e8471e27130bbc019e9bfa6bda16dfc4c6dd7c5d0793da70a9256caeae984"
 dependencies = [
  "anyhow",
- "derive_builder",
+ "bon",
  "rustversion",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,13 +36,13 @@ smb = ["dep:remotefs-smb"]
 smb-vendored = ["remotefs-smb/vendored"]
 
 [dependencies]
-aes = "0.8"
+aes = "0.9"
 aes-gcm = "0.10"
 argh = "0.1"
 base64 = "0.22"
 bitflags = "2"
 bytesize = "2"
-cbc = { version = "0.1", features = ["alloc"] }
+cbc = { version = "0.2", features = ["alloc"] }
 chrono = "0.4"
 content_inspector = "0.2"
 dirs = "6"
@@ -56,12 +56,12 @@ keyring = { version = "3", features = [
 ] }
 lazy-regex = "3"
 log = "0.4"
-md-5 = "0.10"
+md-5 = "0.11"
 notify = "8"
 notify-rust = { version = "4", default-features = false, features = ["d"] }
 nucleo = "0.5"
 open = "5"
-rand = "0.9"
+rand = "0.10"
 regex = "1"
 remotefs = "0.3"
 remotefs-aws-s3 = "0.4"
@@ -111,7 +111,7 @@ serial_test = "3"
 
 [build-dependencies]
 cfg_aliases = "0.2"
-vergen-git2 = { version = "9", features = ["build", "cargo", "rustc", "si"] }
+vergen-git2 = { version = "10", features = ["build", "cargo", "rustc", "si"] }
 
 [[bin]]
 name = "termscp"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,12 +48,7 @@ content_inspector = "0.2"
 dirs = "6"
 edit = "0.1"
 filetime = "0.2"
-keyring = { version = "3", features = [
-  "apple-native",
-  "sync-secret-service",
-  "vendored",
-  "windows-native",
-] }
+keyring-core = "1"
 lazy-regex = "3"
 log = "0.4"
 md-5 = "0.11"
@@ -95,6 +90,12 @@ unicode-width = "0.2"
 whoami = "2"
 wildmatch = "2"
 
+[target."cfg(any(target_os = \"linux\", target_os = \"freebsd\"))".dependencies]
+dbus-secret-service-keyring-store = { version = "1", features = [
+  "crypto-rust",
+  "vendored",
+] }
+
 [target."cfg(target_family = \"unix\")".dependencies]
 remotefs-ftp = { version = "0.4", features = [
   "native-tls",
@@ -104,6 +105,12 @@ uzers = "0.12"
 
 [target."cfg(target_family = \"windows\")".dependencies]
 remotefs-ftp = { version = "0.4", features = ["native-tls"] }
+
+[target."cfg(target_os = \"macos\")".dependencies]
+apple-native-keyring-store = { version = "1", features = ["keychain"] }
+
+[target."cfg(target_os = \"windows\")".dependencies]
+windows-native-keyring-store = "1"
 
 [dev-dependencies]
 pretty_assertions = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "termscp"
-version = "1.0.0"
+version = "1.1.0"
 edition = "2024"
 authors = ["Christian Visintin <christian.visintin@veeso.dev>"]
 description = "termscp is a feature rich terminal file transfer and explorer with support for SCP/SFTP/FTP/Kube/S3/WebDAV"

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 use cfg_aliases::cfg_aliases;
-use vergen_git2::{BuildBuilder, CargoBuilder, Emitter, Git2Builder, RustcBuilder, SysinfoBuilder};
+use vergen_git2::{Build, Cargo, Emitter, Git2, Rustc, Sysinfo};
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Setup cfg aliases
@@ -15,11 +15,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         smb_windows: { all(windows, feature = "smb") }
     }
 
-    let build = BuildBuilder::all_build()?;
-    let cargo = CargoBuilder::all_cargo()?;
-    let git2 = Git2Builder::all_git()?;
-    let rustc = RustcBuilder::all_rustc()?;
-    let si = SysinfoBuilder::all_sysinfo()?;
+    let build = Build::all_build();
+    let cargo = Cargo::all_cargo();
+    let git2 = Git2::all_git();
+    let rustc = Rustc::all_rustc();
+    let si = Sysinfo::all_sysinfo();
 
     Emitter::default()
         .add_instructions(&build)?

--- a/cliff.toml
+++ b/cliff.toml
@@ -17,8 +17,7 @@ Released on {{ timestamp | date(format="%Y-%m-%d") }}
 {%- for group, commits in commits | group_by(attribute="group") %}
 
 ### {{ group | upper_first }}
-
-{%- for commit in commits %}
+{% for commit in commits %}
 - {% if commit.breaking %}💥 {% endif %}{% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.message | split(pat="\n") | first | trim }}
   {%- if commit.body %}
   > {{ commit.body | split(pat="\n") | join(sep="\n  > ") }}
@@ -40,7 +39,7 @@ commit_parsers = [
   { message = "^doc", group = "Documentation" },
   { message = "^test", group = "Testing" },
   { message = "^ci", group = "CI" },
-  { message = "^chore", group = "Miscellaneous" },
+  { message = "^chore", skip = true },
 ]
 filter_commits = false
 tag_pattern = "v[0-9].*"

--- a/src/explorer.rs
+++ b/src/explorer.rs
@@ -159,11 +159,18 @@ impl FileExplorer {
             .insert(PathBuf::from(src), PathBuf::from(dst));
     }
 
-    /// Enqueue all files for transfer
+    /// Enqueue all files for transfer.
+    ///
+    /// `dst` is the destination *directory*; each entry is enqueued with its own
+    /// file name appended, so the stored destination is the full target path.
     pub fn enqueue_all(&mut self, dst: &Path) {
         let files: Vec<_> = self.iter_files().map(|f| f.path.clone()).collect();
         for file in files {
-            self.enqueue(&file, dst);
+            let dest = match file.file_name() {
+                Some(name) => dst.join(name),
+                None => dst.to_path_buf(),
+            };
+            self.enqueue(&file, &dest);
         }
     }
 
@@ -657,6 +664,28 @@ mod tests {
         assert_eq!(explorer.enqueued().len(), 1);
         explorer.dequeue(Path::new("docs"));
         assert_eq!(explorer.enqueued().len(), 0);
+    }
+
+    #[test]
+    fn test_should_enqueue_all_with_dest_file_name() {
+        let mut explorer: FileExplorer = FileExplorer::default();
+        explorer.set_files(vec![
+            make_fs_entry("a.txt", false),
+            make_fs_entry("b.txt", false),
+        ]);
+        // Enqueue all into a remote destination directory
+        explorer.enqueue_all(Path::new("/remote/dir"));
+        let queue = explorer.enqueued();
+        assert_eq!(queue.len(), 2);
+        // Destination must be the directory joined with the file name, not the directory alone
+        assert_eq!(
+            queue.get(Path::new("a.txt")).unwrap(),
+            Path::new("/remote/dir/a.txt")
+        );
+        assert_eq!(
+            queue.get(Path::new("b.txt")).unwrap(),
+            Path::new("/remote/dir/b.txt")
+        );
     }
 
     fn make_fs_entry(name: &str, is_dir: bool) -> File {

--- a/src/system/keys.rs
+++ b/src/system/keys.rs
@@ -6,7 +6,7 @@
 pub mod filestorage;
 pub mod keyringstorage;
 // ext
-use keyring::Error as KeyringError;
+use keyring_core::Error as KeyringError;
 use thiserror::Error;
 
 /// defines the error type for the `KeyStorage`

--- a/src/system/keys/keyringstorage.rs
+++ b/src/system/keys/keyringstorage.rs
@@ -4,9 +4,39 @@
 
 // Local
 // Ext
-use keyring::{Entry as Keyring, Error as KeyringError};
+use std::sync::Once;
+
+use keyring_core::{Entry as Keyring, Error as KeyringError};
 
 use super::{KeyStorage, KeyStorageError};
+
+/// Guards the one-time registration of the process-wide default credential store.
+static INIT_STORE: Once = Once::new();
+
+/// Registers the native credential store as `keyring-core`'s process-wide default.
+///
+/// Unlike `keyring` 3.x, which selected the credential store at compile time via
+/// Cargo features, `keyring-core` 4.x requires the application to register a store
+/// at runtime *before* creating any [`Keyring`] entry. We do this lazily and
+/// exactly once, choosing the native store for the current platform. On platforms
+/// with no supported store nothing is registered, so [`Keyring`] operations fail
+/// and the caller transparently falls back to file-based storage.
+fn ensure_default_store() {
+    INIT_STORE.call_once(|| {
+        #[cfg(target_os = "macos")]
+        if let Ok(store) = apple_native_keyring_store::keychain::Store::new() {
+            keyring_core::set_default_store(store);
+        }
+        #[cfg(target_os = "windows")]
+        if let Ok(store) = windows_native_keyring_store::Store::new() {
+            keyring_core::set_default_store(store);
+        }
+        #[cfg(any(target_os = "linux", target_os = "freebsd"))]
+        if let Ok(store) = dbus_secret_service_keyring_store::Store::new() {
+            keyring_core::set_default_store(store);
+        }
+    });
+}
 
 /// provides a `KeyStorage` implementation using the keyring crate
 pub struct KeyringStorage {
@@ -27,6 +57,7 @@ impl KeyStorage for KeyringStorage {
     /// The key might be acccess through an identifier, which identifies
     /// the key in the storage
     fn get_key(&self, storage_id: &str) -> Result<String, KeyStorageError> {
+        ensure_default_store();
         let storage: Keyring = Keyring::new(storage_id, self.username.as_str())?;
         match storage.get_password() {
             Ok(s) => Ok(s),
@@ -46,6 +77,7 @@ impl KeyStorage for KeyringStorage {
 
     /// Set the key into the key storage
     fn set_key(&self, storage_id: &str, key: &str) -> Result<(), KeyStorageError> {
+        ensure_default_store();
         let storage: Keyring = Keyring::new(storage_id, self.username.as_str())?;
         match storage.set_password(key) {
             Ok(_) => Ok(()),
@@ -57,6 +89,7 @@ impl KeyStorage for KeyringStorage {
     ///
     /// Returns whether the key storage is supported on the host system
     fn is_supported(&self) -> bool {
+        ensure_default_store();
         let dummy: String = String::from("dummy-service");
         let storage: Keyring = match Keyring::new(dummy.as_str(), self.username.as_str()) {
             Ok(s) => s,

--- a/src/ui/activities/filetransfer.rs
+++ b/src/ui/activities/filetransfer.rs
@@ -355,7 +355,12 @@ impl FileTransferActivity {
             self.browser.explorer_mut().dequeue(&src);
         } else {
             debug!("Marking file {}", src.display());
-            let dest = self.browser.other_explorer_no_found().wrkdir.clone();
+            // Destination is the other pane's working directory joined with the file
+            // name, so the queued entry holds the full target path (not just the dir).
+            let mut dest = self.browser.other_explorer_no_found().wrkdir.clone();
+            if let Some(name) = src.file_name() {
+                dest.push(name);
+            }
             self.browser.explorer_mut().enqueue(&src, &dest);
         }
         self.reload_browser_file_list();

--- a/src/utils/crypto.rs
+++ b/src/utils/crypto.rs
@@ -5,7 +5,7 @@
 //! and a zero IV) is transparently decrypted via a fallback path.
 
 use aes::cipher::block_padding::Pkcs7;
-use aes::cipher::{BlockDecryptMut, KeyIvInit};
+use aes::cipher::{BlockModeDecrypt, KeyIvInit};
 use aes_gcm::aead::{Aead, AeadCore};
 use aes_gcm::{Aes128Gcm, KeyInit, Nonce};
 use base64::Engine;
@@ -70,7 +70,7 @@ fn decrypt_legacy_cbc(key: &str, secret: &str) -> Result<String, CryptoError> {
     let raw = B64.decode(secret)?;
     let decryptor = CbcDec::new(&key_bytes.into(), &iv.into());
     let plaintext = decryptor
-        .decrypt_padded_vec_mut::<Pkcs7>(&raw)
+        .decrypt_padded_vec::<Pkcs7>(&raw)
         .map_err(|_| CryptoError::InvalidData)?;
     String::from_utf8(plaintext).map_err(|_| CryptoError::InvalidData)
 }

--- a/src/utils/random.rs
+++ b/src/utils/random.rs
@@ -5,7 +5,7 @@
 // Ext
 
 use rand::distr::Alphanumeric;
-use rand::{Rng as _, rng};
+use rand::{RngExt as _, rng};
 
 /// Generate a random alphanumeric string with provided length
 pub fn random_alphanumeric_with_len(len: usize) -> String {


### PR DESCRIPTION
## What changed

The password store library that termscp uses to save your saved login passwords (the system keyring) had a major new version. The old version is no longer maintained as a usable library, so this updates termscp to the new one. Passwords keep being stored in the same place on your computer (Apple Keychain on macOS, Credential Manager on Windows, Secret Service on Linux), and behavior for you does not change. If a system keyring is not available, termscp still falls back to its encrypted file storage as before.

This also fixes the release build pipeline so it can correctly read the project's version information from git when producing official builds.

It includes a few dependency version bumps that were already part of this branch.

## Why

The keyring library split into separate pieces and stopped shipping the all in one library termscp relied on. Staying on the old version would mean staying on unmaintained code. Moving now keeps password storage secure and supported.

The release builds were downloading only a shallow slice of the project history without version tags. The build step needs the full history and tags to stamp the correct version into the program, so the pipeline could otherwise produce builds with wrong or missing version details.

## Notes

The macOS build was verified locally, including a full save and read and delete cycle against the real system keyring. The Linux and Windows password stores are selected automatically per platform and are covered by the build pipeline on those systems.
