### PR TITLE
build: bump remotefs-smb 0.5.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -241,9 +241,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -252,9 +252,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -1605,7 +1605,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1828,7 +1828,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3418,9 +3418,9 @@ checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "libredox"
-version = "0.1.21"
+version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
+checksum = "8d8f1ea3f21fd3405dcaf6c9b5c1630af9afc422d9073ea39c5f6d6c772e08ed"
 dependencies = [
  "libc",
 ]
@@ -3564,9 +3564,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "log",
@@ -3844,9 +3844,9 @@ checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "open"
-version = "5.4.2"
+version = "5.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade3be4664bc1ef537ce133015f04c176b737815c2ba9fd60edf212d6e90dd55"
+checksum = "7c603ab8300cf18bc3b14146b19fe3dfcc4843ae5a400cd0e7a30b95aa366634"
 dependencies = [
  "is-wsl",
  "libc",
@@ -4120,9 +4120,9 @@ checksum = "1e91099d4268b0e11973f036e885d652fb0b21fedcf69738c627f94db6a44f42"
 
 [[package]]
 name = "pavao"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bf4bff78f032402eb6b89a72801f8d4b5ef57e79d33139f6e4fb214e823a854"
+checksum = "637444e8cbc91d23a07688c41df5dcf5136c34964c8b746c4e40fc2127ef320d"
 dependencies = [
  "cfg_aliases",
  "lazy_static",
@@ -4134,9 +4134,9 @@ dependencies = [
 
 [[package]]
 name = "pavao-src"
-version = "4.22.11"
+version = "4.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48289686720a0215553faa63f3211f0faa57c698287fb1ac41d3fbd423ed1f12"
+checksum = "70a3972383d24edd11da87205cae6d81894919821deb3c336bd715027a630b0b"
 dependencies = [
  "cc",
  "git2",
@@ -4145,9 +4145,9 @@ dependencies = [
 
 [[package]]
 name = "pavao-sys"
-version = "0.3.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c6a44c550ef244c0a19f0a2201687af1853b0b9d1cfaa989a9312942c676adf"
+checksum = "9d77a20ad3376d6f0194f02b7314b4e89402eef920a7c78d7d970d3f2dcd4ac5"
 dependencies = [
  "cc",
  "libc",
@@ -4559,7 +4559,7 @@ dependencies = [
  "once_cell",
  "socket2 0.6.5",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4908,9 +4908,9 @@ dependencies = [
 
 [[package]]
 name = "remotefs-smb"
-version = "0.4.1"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5e5b1fc4afd54e729393b3b44b537583c8e815d0c8e41483799001084e5fe96"
+checksum = "63d9b82c3ca50c6a7cbc923b286192178a6c675476802524e37b41a27c414c57"
 dependencies = [
  "filetime",
  "libc",
@@ -5311,7 +5311,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5388,7 +5388,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -5948,9 +5948,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 
 [[package]]
 name = "smawk"
@@ -5975,7 +5975,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6239,10 +6239,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6520,9 +6520,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "1.1.4+spec-1.1.0"
+version = "1.1.5+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3aace63f4bbcdfc2c965b059de67119c89c4017a70d633be6c104910f67056f5"
+checksum = "12c0ba9680044b4ce98d391a62094047eada0d64860b80166c39f4a6b5640785"
 dependencies = [
  "indexmap 2.14.1",
  "serde_core",
@@ -7198,7 +7198,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,7 +62,7 @@ remotefs = "0.3"
 remotefs-aws-s3 = "0.4"
 remotefs-gcs = "0.1"
 remotefs-kube = "0.4"
-remotefs-smb = { version = "0.4", optional = true }
+remotefs-smb = { version = "0.5", default-features = false, optional = true, features = ["find", "pavao"] }
 remotefs-ssh = { version = "0.9", default-features = false, features = ["russh"] }
 remotefs-webdav = "0.2"
 rpassword = "7"

--- a/src/filetransfer/remotefs_builder.rs
+++ b/src/filetransfer/remotefs_builder.rs
@@ -11,10 +11,11 @@ use remotefs_ftp::FtpFs;
 use remotefs_gcs::credentials::service_account;
 use remotefs_gcs::{GoogleCloudStorageCredentials, GoogleCloudStorageFs};
 use remotefs_kube::KubeMultiPodFs as KubeFs;
-#[cfg(smb)]
-use remotefs_smb::{PavaoSmbCredentials as SmbCredentials, PavaoSmbFs as SmbFs};
 #[cfg(smb_unix)]
-use remotefs_smb::{PavaoSmbOptions as SmbOptions, SmbDialect as RemoteSmbDialect};
+use remotefs_smb::{
+    PavaoSmbCredentials as SmbCredentials, PavaoSmbFs as SmbFs, PavaoSmbOptions as SmbOptions,
+    SmbDialect as RemoteSmbDialect,
+};
 #[cfg(smb_windows)]
 use remotefs_smb::{WNetSmbCredentials as SmbCredentials, WNetSmbFs as SmbFs};
 use remotefs_ssh::{

--- a/src/filetransfer/remotefs_builder.rs
+++ b/src/filetransfer/remotefs_builder.rs
@@ -12,9 +12,11 @@ use remotefs_gcs::credentials::service_account;
 use remotefs_gcs::{GoogleCloudStorageCredentials, GoogleCloudStorageFs};
 use remotefs_kube::KubeMultiPodFs as KubeFs;
 #[cfg(smb)]
-use remotefs_smb::{SmbCredentials, SmbFs};
+use remotefs_smb::{PavaoSmbCredentials as SmbCredentials, PavaoSmbFs as SmbFs};
 #[cfg(smb_unix)]
-use remotefs_smb::{SmbDialect as RemoteSmbDialect, SmbOptions};
+use remotefs_smb::{PavaoSmbOptions as SmbOptions, SmbDialect as RemoteSmbDialect};
+#[cfg(smb_windows)]
+use remotefs_smb::{WNetSmbCredentials as SmbCredentials, WNetSmbFs as SmbFs};
 use remotefs_ssh::{
     NoCheckServerKey, RusshSession as SshSession, ScpFs, SftpFs, SshAgentIdentity,
     SshConfigParseRule, SshOpts,


### PR DESCRIPTION
# Description

Upgraded remotefs-smb to 0.5.0.

This requires explicitly changing the `SmbFs` implementation to `PavaoSmbFs` for unix, and `WNetSmbFs` for Windows.

<!--
Provide a brief description of the changes you made in this pull request. If your changes are related to a specific issue, please mention the issue number (e.g., "Fixes #123").
-->

## Checklist

- [x] I have read the [AI Policy](https://github.com/veeso/termscp/blob/main/AI_POLICY.md) and the [contributing guidelines](https://github.com/veeso/termscp/blob/main/CONTRIBUTING.md).

## AI Disclosure

<!--
Describe how you used AI tools in this contribution. If you did not use any AI tools, write "N/A".
-->

N/A
